### PR TITLE
docs: Update langchain_quick_start.ipynb

### DIFF
--- a/samples/langchain_quick_start.ipynb
+++ b/samples/langchain_quick_start.ipynb
@@ -961,7 +961,7 @@
     "\n",
     "# Intialize the embedding service\n",
     "embeddings_service = VertexAIEmbeddings(\n",
-    "    model_name=\"textembedding-gecko@latest\", project=project_id\n",
+    "    model_name=\"textembedding-gecko@003\", project=project_id\n",
     ")\n",
     "\n",
     "# Intialize the engine\n",


### PR DESCRIPTION
Fix version of vertex ai embeddings so that it uses 003 not just latest.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/langchain-google-alloydb-pg-python/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
