### PR TITLE
chore: remove `ip_type` conversion

### DIFF
--- a/src/langchain_google_alloydb_pg/alloydb_engine.py
+++ b/src/langchain_google_alloydb_pg/alloydb_engine.py
@@ -159,14 +159,6 @@ class AlloyDBEngine:
         if cls._connector is None:
             cls._connector = AsyncConnector(user_agent=USER_AGENT)
 
-        if isinstance(ip_type, str):
-            if ip_type.lower() == "public":
-                ip_type = IPTypes.PUBLIC
-            elif ip_type.lower() == "private":
-                ip_type = IPTypes.PRIVATE
-            else:
-                raise ValueError("ip_type is not one of: public, private.")
-
         # if user and password are given, use basic auth
         if user and password:
             enable_iam_auth = False


### PR DESCRIPTION
No longer need to convert the `ip_type` to the Python Connector enum.

I added native support for `ip_type` as `str` to the AlloyDB Python Connector. Now the converting can be offloaded and not required here in the langchain package.

Ref: https://github.com/GoogleCloudPlatform/alloydb-python-connector/pull/267

P.S: This will also add PSC support for free once the Python Connector version is bumped to 1.1.0 which has PSC support (released today).