### PR TITLE
chore: Set up github teams ownership and permission

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-*   @googleapis/senseai-eco  @tabbyl21
+*   @googleapis/senseai-eco  @googleapis/langchain-alloydb

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -42,3 +42,5 @@ branchProtectionRules:
 permissionRules:
   - team: senseai-eco
     permission: admin
+  - team: langchain-alloydb
+    permission: push


### PR DESCRIPTION
1. set langchain-alloydb github team as owner
2. give it `push` permission