### PR TITLE
fix: update required dependencies to use SQLAlchemy[asyncio]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "numpy==1.24.4; python_version<='3.8'",
     "numpy>=1.24.4, <2.0.0; python_version>'3.8'",
     "pgvector>=0.2.5, <1.0.0",
-    "SQLAlchemy>=2.0.25, <3.0.0"
+    "SQLAlchemy[asyncio]>=2.0.25, <3.0.0"
 ]
 
 [tool.setuptools.dynamic]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ langchain-community==0.0.34
 numpy===1.24.4; python_version <= "3.8"
 numpy==1.26.4; python_version > "3.8"
 pgvector==0.2.5
-SQLAlchemy==2.0.29
+SQLAlchemy[asyncio]==2.0.29


### PR DESCRIPTION
This library uses only async SQLAlchemy connection pool engines. Thus, it should be depending on `sqlalchemy[asyncio]` and not regular sqlalchemy.

This will fix required deps on macOS: https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html#asyncio-platform-installation-notes-including-apple-m1

Fixes #115 