### PR TITLE
refactor: return early if credentials have service account field

### DIFF
--- a/src/langchain_google_alloydb_pg/alloydb_engine.py
+++ b/src/langchain_google_alloydb_pg/alloydb_engine.py
@@ -60,7 +60,7 @@ async def _get_iam_principal_email(
         request = google.auth.transport.requests.Request()
         credentials.refresh(request)
     if hasattr(credentials, "_service_account_email"):
-        email = credentials._service_account_email
+        return credentials._service_account_email.replace(".gserviceaccount.com", "")
     # call OAuth2 api to get IAM principal email associated with OAuth2 token
     url = f"https://oauth2.googleapis.com/tokeninfo?access_token={credentials.token}"
     async with aiohttp.ClientSession() as client:


### PR DESCRIPTION
As pointed out in #110 there is no point of calling the Google OAuth2 endpoint if we already have the service account field tied to the credentials... unless I'm missing something. 

https://github.com/googleapis/langchain-google-alloydb-pg-python/blob/9ce7a4bc4257d7e0fe90c1bab1740326b4c7d12f/src/langchain_google_alloydb_pg/alloydb_engine.py#L62-L75

We should be returning early and skipping the overhead of the API call if we already know the IAM principal based on the credentials attribute. This is what we do already in the [Cloud SQL MySQL package](https://github.com/googleapis/langchain-google-cloud-sql-mysql-python/blob/main/src/langchain_google_cloud_sql_mysql/engine.py#L73).

