### PR TITLE
fix: use lazy refresh for AlloyDB Connector

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
     {name = "Google LLC", email = "googleapis-packages@google.com"}
 ]
 dependencies = [
-    "google-cloud-alloydb-connector[asyncpg]>=1.0.0, <2.0.0",
+    "google-cloud-alloydb-connector[asyncpg]>=1.2.0, <2.0.0",
     "langchain-core>=0.1.1, <1.0.0",
     "langchain-community>=0.0.18, <1.0.0",
     "numpy>=1.24.4, <2.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-google-cloud-alloydb-connector[asyncpg]==1.1.2
+google-cloud-alloydb-connector[asyncpg]==1.2.0
 langchain-core==0.2.9
 langchain-community==0.2.5
 numpy===1.24.4; python_version <= "3.8"

--- a/src/langchain_google_alloydb_pg/alloydb_engine.py
+++ b/src/langchain_google_alloydb_pg/alloydb_engine.py
@@ -32,7 +32,7 @@ from typing import (
 import aiohttp
 import google.auth  # type: ignore
 import google.auth.transport.requests  # type: ignore
-from google.cloud.alloydb.connector import AsyncConnector, IPTypes
+from google.cloud.alloydb.connector import AsyncConnector, IPTypes, RefreshStrategy
 from sqlalchemy import MetaData, RowMapping, Table, text
 from sqlalchemy.exc import InvalidRequestError
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
@@ -167,7 +167,9 @@ class AlloyDBEngine:
             )
 
         if cls._connector is None:
-            cls._connector = AsyncConnector(user_agent=USER_AGENT)
+            cls._connector = AsyncConnector(
+                user_agent=USER_AGENT, refresh_strategy=RefreshStrategy.LAZY
+            )
 
         # if user and password are given, use basic auth
         if user and password:


### PR DESCRIPTION
The AlloyDB Python Connector just released a new version `v1.2.0`
that supports setting the `refresh_strategy` argument of the connector.

Setting the refresh strategy to lazy refresh is recommended for
serverless environments. As the default refresh strategy is to
have background refreshes occur to get the instance metadata and a fresh
certificate to use for the SSL/TLS connection. 

However, these background refreshes can be throttled when serverless 
environments scale to zero (Cloud Functions, Cloud Run etc.).

This PR will fix the ambiguous errors that are a result of the CPU being
throttled for the AlloyDB Connector.

Fixes #160 
