### PR TITLE
fix: Change IVFFlat `lists` default to 100

### DIFF
--- a/src/langchain_google_alloydb_pg/indexes.py
+++ b/src/langchain_google_alloydb_pg/indexes.py
@@ -87,7 +87,7 @@ class HNSWQueryOptions(QueryOptions):
 @dataclass
 class IVFFlatIndex(BaseIndex):
     index_type: str = "ivfflat"
-    lists: int = 1
+    lists: int = 100
 
     def index_options(self) -> str:
         return f"(lists = {self.lists})"


### PR DESCRIPTION
`pgvector` has IVFFlat `lists` parameter default to `100`(https://github.com/pgvector/pgvector/blob/d1694a93afe4d23d0bc3ca6f9c85f06fb79a325c/src/ivfflat.h#L42) but our implementation defaults to `1`. We should change the default to match the `pgvector` setting.