### PR TITLE
feat: Add similarity search score threshold select function

### DIFF
--- a/src/langchain_google_alloydb_pg/vectorstore.py
+++ b/src/langchain_google_alloydb_pg/vectorstore.py
@@ -57,7 +57,7 @@ class AlloyDBVectorStore(VectorStore):
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
         index_query_options: Optional[QueryOptions] = None,
-        relevence_score_fn = Optional[Callable[[float], float]] = None,
+        relevence_score_fn: Optional[Callable[[float], float]] = None,
     ):
         if key != AlloyDBVectorStore.__create_key:
             raise Exception(
@@ -512,7 +512,6 @@ class AlloyDBVectorStore(VectorStore):
             return self._max_inner_product_relevance_score_fn
         elif self.distance_strategy == DistanceStrategy.EUCLIDEAN:
             return self._euclidean_relevance_score_fn
-
 
     async def asimilarity_search_with_score(
         self,

--- a/src/langchain_google_alloydb_pg/vectorstore.py
+++ b/src/langchain_google_alloydb_pg/vectorstore.py
@@ -57,7 +57,7 @@ class AlloyDBVectorStore(VectorStore):
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
         index_query_options: Optional[QueryOptions] = None,
-        relevence_score_fn: Optional[Callable[[float], float]] = None,
+        relevance_score_fn: Optional[Callable[[float], float]] = None,
     ):
         if key != AlloyDBVectorStore.__create_key:
             raise Exception(
@@ -77,7 +77,7 @@ class AlloyDBVectorStore(VectorStore):
         self.fetch_k = fetch_k
         self.lambda_mult = lambda_mult
         self.index_query_options = index_query_options
-        self.relevence_score_fn = relevence_score_fn
+        self.relevance_score_fn = relevance_score_fn
 
     @classmethod
     async def create(

--- a/src/langchain_google_alloydb_pg/vectorstore.py
+++ b/src/langchain_google_alloydb_pg/vectorstore.py
@@ -459,6 +459,7 @@ class AlloyDBVectorStore(VectorStore):
         embedding: List[float],
         k: Optional[int] = None,
         filter: Optional[str] = None,
+        **kwargs: Any,
     ) -> Sequence[RowMapping]:
         k = k if k else self.k
         operator = self.distance_strategy.operator

--- a/src/langchain_google_alloydb_pg/vectorstore.py
+++ b/src/langchain_google_alloydb_pg/vectorstore.py
@@ -96,6 +96,7 @@ class AlloyDBVectorStore(VectorStore):
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
         index_query_options: Optional[QueryOptions] = None,
+        relevance_score_fn: Optional[Callable[[float], float]] = None,
     ) -> AlloyDBVectorStore:
         """Constructor for AlloyDBVectorStore.
         Args:
@@ -172,6 +173,7 @@ class AlloyDBVectorStore(VectorStore):
             fetch_k,
             lambda_mult,
             index_query_options,
+            relevance_score_fn,
         )
 
     @classmethod
@@ -191,6 +193,7 @@ class AlloyDBVectorStore(VectorStore):
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
         index_query_options: Optional[QueryOptions] = None,
+        relevance_score_fn: Optional[Callable[[float], float]] = None,
     ) -> AlloyDBVectorStore:
         coro = cls.create(
             engine,
@@ -207,6 +210,7 @@ class AlloyDBVectorStore(VectorStore):
             fetch_k,
             lambda_mult,
             index_query_options,
+            relevance_score_fn,
         )
         return engine._run_as_sync(coro)
 

--- a/src/langchain_google_alloydb_pg/vectorstore.py
+++ b/src/langchain_google_alloydb_pg/vectorstore.py
@@ -109,6 +109,7 @@ class AlloyDBVectorStore(VectorStore):
             ignore_metadata_columns (List[str]): Column(s) to ignore in pre-existing tables for a document's metadata. Can not be used with metadata_columns. Defaults to None.
             id_column (str): Column that represents the Document's id. Defaults to "langchain_id".
             metadata_json_column (str): Column to store metadata as JSON. Defaults to "langchain_metadata".
+            relevance_score_fn (Callable): custom function to overrides default relevance score calculation functions.
         """
         if metadata_columns and ignore_metadata_columns:
             raise ValueError(

--- a/src/langchain_google_alloydb_pg/vectorstore.py
+++ b/src/langchain_google_alloydb_pg/vectorstore.py
@@ -57,7 +57,6 @@ class AlloyDBVectorStore(VectorStore):
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
         index_query_options: Optional[QueryOptions] = None,
-        relevance_score_fn: Optional[Callable[[float], float]] = None,
     ):
         if key != AlloyDBVectorStore.__create_key:
             raise Exception(
@@ -77,7 +76,6 @@ class AlloyDBVectorStore(VectorStore):
         self.fetch_k = fetch_k
         self.lambda_mult = lambda_mult
         self.index_query_options = index_query_options
-        self.relevance_score_fn = relevance_score_fn
 
     @classmethod
     async def create(
@@ -96,7 +94,6 @@ class AlloyDBVectorStore(VectorStore):
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
         index_query_options: Optional[QueryOptions] = None,
-        relevance_score_fn: Optional[Callable[[float], float]] = None,
     ) -> AlloyDBVectorStore:
         """Constructor for AlloyDBVectorStore.
         Args:
@@ -109,7 +106,6 @@ class AlloyDBVectorStore(VectorStore):
             ignore_metadata_columns (List[str]): Column(s) to ignore in pre-existing tables for a document's metadata. Can not be used with metadata_columns. Defaults to None.
             id_column (str): Column that represents the Document's id. Defaults to "langchain_id".
             metadata_json_column (str): Column to store metadata as JSON. Defaults to "langchain_metadata".
-            relevance_score_fn (Callable): custom function to overrides default relevance score calculation functions.
         """
         if metadata_columns and ignore_metadata_columns:
             raise ValueError(
@@ -174,7 +170,6 @@ class AlloyDBVectorStore(VectorStore):
             fetch_k,
             lambda_mult,
             index_query_options,
-            relevance_score_fn,
         )
 
     @classmethod
@@ -194,7 +189,6 @@ class AlloyDBVectorStore(VectorStore):
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
         index_query_options: Optional[QueryOptions] = None,
-        relevance_score_fn: Optional[Callable[[float], float]] = None,
     ) -> AlloyDBVectorStore:
         coro = cls.create(
             engine,
@@ -211,7 +205,6 @@ class AlloyDBVectorStore(VectorStore):
             fetch_k,
             lambda_mult,
             index_query_options,
-            relevance_score_fn,
         )
         return engine._run_as_sync(coro)
 
@@ -507,9 +500,6 @@ class AlloyDBVectorStore(VectorStore):
         """
         Select a relevance function based on distance strategy
         """
-        if self.relevance_score_fn is not None:
-            return self.relevance_score_fn
-
         # Calculate distance strategy provided in
         # vectorstore constructor
         if self.distance_strategy == DistanceStrategy.COSINE_DISTANCE:

--- a/tests/test_alloydb_vectorstore_search.py
+++ b/tests/test_alloydb_vectorstore_search.py
@@ -154,9 +154,9 @@ class TestVectorStoreSearch:
         results = await vs.asimilarity_search_with_relevance_scores(
             "foo", **score_threshold
         )
+        print(results)
         assert len(results) == 1
         assert results[0][0] == Document(page_content="foo")
-        assert results[0][1] == 0
 
     async def test_asimilarity_search_by_vector(self, vs):
         embedding = embeddings_service.embed_query("foo")

--- a/tests/test_alloydb_vectorstore_search.py
+++ b/tests/test_alloydb_vectorstore_search.py
@@ -149,9 +149,11 @@ class TestVectorStoreSearch:
         assert results[0][0] == Document(page_content="foo")
         assert results[0][1] == 0
 
-    async def test_asimilarity_search_score_with_threshold(self, vs):
+    async def test_similarity_search_with_relevance_scores_threshold(self, vs):
         score_threshold = {"score_threshold": 0.8}
-        results = await vs.asimilarity_search_with_score("joo", **score_threshold)
+        results = await vs.asimilarity_search_with_relevance_scores(
+            "joo", **score_threshold
+        )
         assert len(results) == 2
         assert results[0][0] == Document(page_content="foo")
         assert results[0][1] == 0

--- a/tests/test_alloydb_vectorstore_search.py
+++ b/tests/test_alloydb_vectorstore_search.py
@@ -149,6 +149,13 @@ class TestVectorStoreSearch:
         assert results[0][0] == Document(page_content="foo")
         assert results[0][1] == 0
 
+    async def test_asimilarity_search_score_with_threshold(self, vs):
+        score_threshold = {"score_threshold": 0.8}
+        results = await vs.asimilarity_search_with_score("joo", **score_threshold)
+        assert len(results) == 2
+        assert results[0][0] == Document(page_content="foo")
+        assert results[0][1] == 0
+
     async def test_asimilarity_search_by_vector(self, vs):
         embedding = embeddings_service.embed_query("foo")
         results = await vs.asimilarity_search_by_vector(embedding)

--- a/tests/test_alloydb_vectorstore_search.py
+++ b/tests/test_alloydb_vectorstore_search.py
@@ -154,7 +154,6 @@ class TestVectorStoreSearch:
         results = await vs.asimilarity_search_with_relevance_scores(
             "foo", **score_threshold
         )
-        print(results)
         assert len(results) == 1
         assert results[0][0] == Document(page_content="foo")
 

--- a/tests/test_alloydb_vectorstore_search.py
+++ b/tests/test_alloydb_vectorstore_search.py
@@ -150,10 +150,14 @@ class TestVectorStoreSearch:
         assert results[0][1] == 0
 
     async def test_similarity_search_with_relevance_scores_threshold(self, vs):
-        score_threshold = {"score_threshold": 0.5}
+        # score_threshold = {"score_threshold": 0.5}
+        # results = await vs.asimilarity_search_with_relevance_scores(
+        #     "joo", **score_threshold
+        # )
         results = await vs.asimilarity_search_with_relevance_scores(
-            "joo", **score_threshold
+            "joo",
         )
+        print(results)
         assert len(results) == 2
         assert results[0][0] == Document(page_content="foo")
         assert results[0][1] == 0

--- a/tests/test_alloydb_vectorstore_search.py
+++ b/tests/test_alloydb_vectorstore_search.py
@@ -150,15 +150,11 @@ class TestVectorStoreSearch:
         assert results[0][1] == 0
 
     async def test_similarity_search_with_relevance_scores_threshold(self, vs):
-        # score_threshold = {"score_threshold": 0.5}
-        # results = await vs.asimilarity_search_with_relevance_scores(
-        #     "joo", **score_threshold
-        # )
+        score_threshold = {"score_threshold": 0.9}
         results = await vs.asimilarity_search_with_relevance_scores(
-            "joo",
+            "foo", **score_threshold
         )
-        print(results)
-        assert len(results) == 2
+        assert len(results) == 1
         assert results[0][0] == Document(page_content="foo")
         assert results[0][1] == 0
 

--- a/tests/test_alloydb_vectorstore_search.py
+++ b/tests/test_alloydb_vectorstore_search.py
@@ -150,6 +150,12 @@ class TestVectorStoreSearch:
         assert results[0][1] == 0
 
     async def test_similarity_search_with_relevance_scores_threshold(self, vs):
+        score_threshold = {"score_threshold": 0}
+        results = await vs.asimilarity_search_with_relevance_scores(
+            "foo", **score_threshold
+        )
+        assert len(results) == 4
+        print(results)
         score_threshold = {"score_threshold": 0.9}
         results = await vs.asimilarity_search_with_relevance_scores(
             "foo", **score_threshold
@@ -157,17 +163,11 @@ class TestVectorStoreSearch:
         assert len(results) == 1
         assert results[0][0] == Document(page_content="foo")
 
-        score_threshold = {"score_threshold": 0.1}
+        score_threshold = {"score_threshold": 0.01}
         results = await vs.asimilarity_search_with_relevance_scores(
             "foo", **score_threshold
         )
         assert len(results) == 2
-
-        score_threshold = {"score_threshold": 0}
-        results = await vs.asimilarity_search_with_relevance_scores(
-            "foo", **score_threshold
-        )
-        assert len(results) == 4
 
     async def test_asimilarity_search_by_vector(self, vs):
         embedding = embeddings_service.embed_query("foo")

--- a/tests/test_alloydb_vectorstore_search.py
+++ b/tests/test_alloydb_vectorstore_search.py
@@ -155,19 +155,19 @@ class TestVectorStoreSearch:
             "foo", **score_threshold
         )
         assert len(results) == 4
-        print(results)
+
+        score_threshold = {"score_threshold": 0.02}
+        results = await vs.asimilarity_search_with_relevance_scores(
+            "foo", **score_threshold
+        )
+        assert len(results) == 2
+
         score_threshold = {"score_threshold": 0.9}
         results = await vs.asimilarity_search_with_relevance_scores(
             "foo", **score_threshold
         )
         assert len(results) == 1
         assert results[0][0] == Document(page_content="foo")
-
-        score_threshold = {"score_threshold": 0.01}
-        results = await vs.asimilarity_search_with_relevance_scores(
-            "foo", **score_threshold
-        )
-        assert len(results) == 2
 
     async def test_asimilarity_search_by_vector(self, vs):
         embedding = embeddings_service.embed_query("foo")

--- a/tests/test_alloydb_vectorstore_search.py
+++ b/tests/test_alloydb_vectorstore_search.py
@@ -150,7 +150,7 @@ class TestVectorStoreSearch:
         assert results[0][1] == 0
 
     async def test_similarity_search_with_relevance_scores_threshold(self, vs):
-        score_threshold = {"score_threshold": 0.8}
+        score_threshold = {"score_threshold": 0.5}
         results = await vs.asimilarity_search_with_relevance_scores(
             "joo", **score_threshold
         )

--- a/tests/test_alloydb_vectorstore_search.py
+++ b/tests/test_alloydb_vectorstore_search.py
@@ -157,7 +157,7 @@ class TestVectorStoreSearch:
         assert len(results) == 1
         assert results[0][0] == Document(page_content="foo")
 
-        score_threshold = {"score_threshold": 0.3}
+        score_threshold = {"score_threshold": 0.1}
         results = await vs.asimilarity_search_with_relevance_scores(
             "foo", **score_threshold
         )

--- a/tests/test_alloydb_vectorstore_search.py
+++ b/tests/test_alloydb_vectorstore_search.py
@@ -157,6 +157,18 @@ class TestVectorStoreSearch:
         assert len(results) == 1
         assert results[0][0] == Document(page_content="foo")
 
+        score_threshold = {"score_threshold": 0.3}
+        results = await vs.asimilarity_search_with_relevance_scores(
+            "foo", **score_threshold
+        )
+        assert len(results) == 2
+
+        score_threshold = {"score_threshold": 0}
+        results = await vs.asimilarity_search_with_relevance_scores(
+            "foo", **score_threshold
+        )
+        assert len(results) == 4
+
     async def test_asimilarity_search_by_vector(self, vs):
         embedding = embeddings_service.embed_query("foo")
         results = await vs.asimilarity_search_by_vector(embedding)


### PR DESCRIPTION
Implements LangChain `_select_relevance_score_fn` function to support similarity search with score threshold: https://github.com/langchain-ai/langchain/blob/cb95198398a66737f1a7f7e0f63417802e03190c/libs/core/langchain_core/vectorstores/base.py#L611

btw fix a titel size in README.rst