### PR TITLE
feat: Add table name to default index name

### DIFF
--- a/src/langchain_google_alloydb_pg/indexes.py
+++ b/src/langchain_google_alloydb_pg/indexes.py
@@ -35,12 +35,12 @@ class DistanceStrategy(StrategyMixin, enum.Enum):
 
 
 DEFAULT_DISTANCE_STRATEGY: DistanceStrategy = DistanceStrategy.COSINE_DISTANCE
-DEFAULT_INDEX_NAME: str = "langchainvectorindex"
+DEFAULT_INDEX_NAME_SUFFIX: str = "langchainvectorindex"
 
 
 @dataclass
 class BaseIndex(ABC):
-    name: str = DEFAULT_INDEX_NAME
+    name: str = DEFAULT_INDEX_NAME_SUFFIX
     index_type: str = "base"
     distance_strategy: DistanceStrategy = field(
         default_factory=lambda: DistanceStrategy.COSINE_DISTANCE

--- a/src/langchain_google_alloydb_pg/indexes.py
+++ b/src/langchain_google_alloydb_pg/indexes.py
@@ -40,7 +40,7 @@ DEFAULT_INDEX_NAME_SUFFIX: str = "langchainvectorindex"
 
 @dataclass
 class BaseIndex(ABC):
-    name: str = DEFAULT_INDEX_NAME_SUFFIX
+    name: Optional[str] = None
     index_type: str = "base"
     distance_strategy: DistanceStrategy = field(
         default_factory=lambda: DistanceStrategy.COSINE_DISTANCE

--- a/src/langchain_google_alloydb_pg/vectorstore.py
+++ b/src/langchain_google_alloydb_pg/vectorstore.py
@@ -770,14 +770,14 @@ class AlloyDBVectorStore(VectorStore):
         else:
             await self.engine._aexecute(stmt)
 
-    async def areindex(self, index_name: str = None) -> None:
+    async def areindex(self, index_name: Optional[str] = None) -> None:
         index_name = index_name or self.table_name + DEFAULT_INDEX_NAME_SUFFIX
         query = f"REINDEX INDEX {index_name};"
         await self.engine._aexecute(query)
 
     async def adrop_vector_index(
         self,
-        index_name: str = None,
+        index_name: Optional[str] = None,
     ) -> None:
         index_name = index_name or self.table_name + DEFAULT_INDEX_NAME_SUFFIX
         query = f"DROP INDEX IF EXISTS {index_name};"
@@ -785,7 +785,7 @@ class AlloyDBVectorStore(VectorStore):
 
     async def is_valid_index(
         self,
-        index_name: str = None,
+        index_name: Optional[str] = None,
     ) -> bool:
         index_name = index_name or self.table_name + DEFAULT_INDEX_NAME_SUFFIX
         query = f"""

--- a/src/langchain_google_alloydb_pg/vectorstore.py
+++ b/src/langchain_google_alloydb_pg/vectorstore.py
@@ -759,11 +759,10 @@ class AlloyDBVectorStore(VectorStore):
 
         filter = f"WHERE ({index.partial_indexes})" if index.partial_indexes else ""
         params = "WITH " + index.index_options()
-        index_name = name
-        if index_name is None:
-            if index.name == DEFAULT_INDEX_NAME_SUFFIX:
+        if name is None:
+            if index.name == None:
                 index.name = self.table_name + DEFAULT_INDEX_NAME_SUFFIX
-            index_name = index.name
+            name = index.name
         stmt = f"CREATE INDEX {'CONCURRENTLY' if concurrently else ''} {name} ON \"{self.table_name}\" USING {index.index_type} ({self.embedding_column} {function}) {params} {filter};"
         if concurrently:
             await self.engine._aexecute_outside_tx(stmt)

--- a/tests/test_alloydb_vectorstore_index.py
+++ b/tests/test_alloydb_vectorstore_index.py
@@ -34,8 +34,8 @@ from langchain_google_alloydb_pg.indexes import (
 
 DEFAULT_TABLE = "test_table" + str(uuid.uuid4()).replace("-", "_")
 CUSTOM_TABLE = "test_table_custom" + str(uuid.uuid4()).replace("-", "_")
-VECTOR_SIZE = 768
 DEFAULT_INDEX_NAME = DEFAULT_TABLE + DEFAULT_INDEX_NAME_SUFFIX
+VECTOR_SIZE = 768
 
 embeddings_service = DeterministicFakeEmbedding(size=VECTOR_SIZE)
 
@@ -195,9 +195,7 @@ class TestIndex:
         index = ScaNNIndex(distance_strategy=DistanceStrategy.EUCLIDEAN)
         await omni_vs.set_maintenance_work_mem(index.num_leaves, VECTOR_SIZE)
         await omni_vs.aapply_vector_index(index, concurrently=True)
-        assert await omni_vs.is_valid_index(
-            omni_vs.table_name + DEFAULT_INDEX_NAME_SUFFIX
-        )
+        assert await omni_vs.is_valid_index(DEFAULT_INDEX_NAME)
         index = ScaNNIndex(
             name="secondindex",
             distance_strategy=DistanceStrategy.COSINE_DISTANCE,

--- a/tests/test_alloydb_vectorstore_index.py
+++ b/tests/test_alloydb_vectorstore_index.py
@@ -35,7 +35,7 @@ from langchain_google_alloydb_pg.indexes import (
 DEFAULT_TABLE = "test_table" + str(uuid.uuid4()).replace("-", "_")
 CUSTOM_TABLE = "test_table_custom" + str(uuid.uuid4()).replace("-", "_")
 VECTOR_SIZE = 768
-DEFAULT_INDEX_NAME = None
+DEFAULT_INDEX_NAME = DEFAULT_TABLE + DEFAULT_INDEX_NAME_SUFFIX
 
 embeddings_service = DeterministicFakeEmbedding(size=VECTOR_SIZE)
 
@@ -101,8 +101,7 @@ class TestIndex:
             embedding_service=embeddings_service,
             table_name=DEFAULT_TABLE,
         )
-        global DEFAULT_INDEX_NAME
-        DEFAULT_INDEX_NAME = vs.table_name + DEFAULT_INDEX_NAME_SUFFIX
+
         await vs.aadd_texts(texts, ids=ids)
         await vs.adrop_vector_index()
         yield vs


### PR DESCRIPTION
Add table name as prefix to default index name upon index creation to avoid conflicting default index names for different tables.
1. Change `DEFAULT_INDEX_NAME` to `DEFAULT_INDEX_NAME_SUFFIX`.
2. Change `index_name` default in the `BaseIndex` class to `None`.
3. In `aapply_vector_index()`, check if the `index_name` field is `None` and if so, give it a default index name (`table_name` + `DEFAULT_INDEX_NAME_SUFFIX`).