### PR TITLE
feat: Auto-generate IDs upon adding embeddings

### DIFF
--- a/src/langchain_google_alloydb_pg/loader.py
+++ b/src/langchain_google_alloydb_pg/loader.py
@@ -150,7 +150,7 @@ class AlloyDBLoader(BaseLoader):
             query (Optional[str], optional): SQL query. Defaults to None.
             table_name (Optional[str], optional): Name of table to query. Defaults to None.
             content_columns (Optional[List[str]], optional): Column that represent a Document's page_content. Defaults to the first column.
-            metadata_columns (Optional[List[str]], optional): Column(s) that represent a Document's metadata.. Defaults to None.
+            metadata_columns (Optional[List[str]], optional): Column(s) that represent a Document's metadata. Defaults to None.
             metadata_json_column (Optional[str], optional): Column to store metadata as JSON. Defaults to "langchain_metadata".
             format (Optional[str], optional): Format of page content (OneOf: text, csv, YAML, JSON). Defaults to 'text'.
             formatter (Optional[Callable], optional): A function to format page content (OneOf: format, formatter). Defaults to None.

--- a/src/langchain_google_alloydb_pg/vectorstore.py
+++ b/src/langchain_google_alloydb_pg/vectorstore.py
@@ -221,7 +221,7 @@ class AlloyDBVectorStore(VectorStore):
         **kwargs: Any,
     ) -> List[str]:
         if not ids:
-            ids = [str(i) for i, _ in enumerate(texts)]
+            ids = [str(uuid.uuid4()) for _ in texts]
         if not metadatas:
             metadatas = [{} for _ in texts]
         # Insert embeddings

--- a/src/langchain_google_alloydb_pg/vectorstore.py
+++ b/src/langchain_google_alloydb_pg/vectorstore.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import json
+import uuid
 from typing import Any, Iterable, List, Optional, Sequence, Tuple, Type, Union
 
 import numpy as np

--- a/src/langchain_google_alloydb_pg/vectorstore.py
+++ b/src/langchain_google_alloydb_pg/vectorstore.py
@@ -221,7 +221,7 @@ class AlloyDBVectorStore(VectorStore):
         **kwargs: Any,
     ) -> List[str]:
         if not ids:
-            ids = ["NULL" for _ in texts]
+            ids = list(range(len(texts)))
         if not metadatas:
             metadatas = [{} for _ in texts]
         # Insert embeddings

--- a/src/langchain_google_alloydb_pg/vectorstore.py
+++ b/src/langchain_google_alloydb_pg/vectorstore.py
@@ -221,7 +221,7 @@ class AlloyDBVectorStore(VectorStore):
         **kwargs: Any,
     ) -> List[str]:
         if not ids:
-            ids = [i for i, _ in enumerate(texts)]
+            ids = [str(i) for i, _ in enumerate(texts)]
         if not metadatas:
             metadatas = [{} for _ in texts]
         # Insert embeddings

--- a/src/langchain_google_alloydb_pg/vectorstore.py
+++ b/src/langchain_google_alloydb_pg/vectorstore.py
@@ -221,7 +221,7 @@ class AlloyDBVectorStore(VectorStore):
         **kwargs: Any,
     ) -> List[str]:
         if not ids:
-            ids = list(range(len(texts)))
+            ids = [i for i, _ in enumerate(texts)]
         if not metadatas:
             metadatas = [{} for _ in texts]
         # Insert embeddings

--- a/tests/test_alloydb_vectorstore.py
+++ b/tests/test_alloydb_vectorstore.py
@@ -186,6 +186,13 @@ class TestVectorStore:
         assert len(results) == 3
         await engine._aexecute(f'TRUNCATE TABLE "{DEFAULT_TABLE}"')
 
+    async def test_aadd_embedding_without_id(self, engine, vs):
+        await vs._aadd_embeddings(texts, embeddings, metadatas)
+        results = await engine._afetch(f'SELECT * FROM "{DEFAULT_TABLE}"')
+        assert len(results) == 3
+        assert results[0]["langchain_id"]
+        await engine._aexecute(f'TRUNCATE TABLE "{DEFAULT_TABLE}"')
+
     async def test_adelete(self, engine, vs):
         ids = [str(uuid.uuid4()) for i in range(len(texts))]
         await vs.aadd_texts(texts, ids=ids)


### PR DESCRIPTION
If the user doesn't provide IDs when adding vector store embeddings, auto-generate integer IDs for them.