### PR TITLE
fix: Rename inner product distance search function to `inner_product`

### DIFF
--- a/src/langchain_google_alloydb_pg/indexes.py
+++ b/src/langchain_google_alloydb_pg/indexes.py
@@ -31,7 +31,7 @@ class DistanceStrategy(StrategyMixin, enum.Enum):
 
     EUCLIDEAN = "<->", "l2_distance", "vector_l2_ops", "l2"
     COSINE_DISTANCE = "<=>", "cosine_distance", "vector_cosine_ops", "cosine"
-    INNER_PRODUCT = "<#>", "ip_distance", "vector_ip_ops", "dot_product"
+    INNER_PRODUCT = "<#>", "inner_product", "vector_ip_ops", "dot_product"
 
 
 DEFAULT_DISTANCE_STRATEGY: DistanceStrategy = DistanceStrategy.COSINE_DISTANCE


### PR DESCRIPTION
pgvector reference for vector functions: https://github.com/pgvector/pgvector?tab=readme-ov-file#vector-functions