### PR TITLE
docs: Sample to use AlloyDB interface for vector search in PGVector database

### DIFF
--- a/samples/pg_to_alloy_migration_search.ipynb
+++ b/samples/pg_to_alloy_migration_search.ipynb
@@ -317,8 +317,8 @@
     "\n",
     "PGvector sets up two tables. \n",
     "\n",
-    "1. langchain_pg_collection: contains the uuid corresponding to each collection.\n",
-    "2. langchain_pg_embedding: contains documents belonging to all collections."
+    "1. `langchain_pg_collection`: contains the uuid corresponding to each collection.\n",
+    "2. `langchain_pg_embedding`: contains documents belonging to all collections."
    ]
   },
   {

--- a/samples/pg_to_alloy_migration_search.ipynb
+++ b/samples/pg_to_alloy_migration_search.ipynb
@@ -54,7 +54,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -62,15 +62,7 @@
         "id": "t-FWrCqVH7v5",
         "outputId": "e9e30198-d2ca-4365-b21b-d6ab0eeb0623"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Note: you may need to restart the kernel to use updated packages.\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "%pip install --upgrade --quiet  langchain-google-alloydb-pg langchain-google-vertexai"
       ]
@@ -86,7 +78,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "execution_count": null,
       "metadata": {
         "id": "ziswhCwcY_MV"
       },
@@ -115,23 +107,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": null,
       "metadata": {
         "id": "MLA9smX8OBcM"
       },
-      "outputs": [
-        {
-          "ename": "ModuleNotFoundError",
-          "evalue": "No module named 'google.colab'",
-          "output_type": "error",
-          "traceback": [
-            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-            "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
-            "Cell \u001b[0;32mIn[3], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mgoogle\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mcolab\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m auth\n\u001b[1;32m      3\u001b[0m auth\u001b[38;5;241m.\u001b[39mauthenticate_user()\n",
-            "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'google.colab'"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "from google.colab import auth\n",
         "\n",
@@ -164,15 +144,7 @@
         "id": "TqWdttLHOEsr",
         "outputId": "29fa03ed-de0b-4ac1-95e7-6d33e566e66a"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Updated property [core/project].\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "# @markdown Please fill in the value below with your Google Cloud project ID and then run the cell.\n",
         "\n",
@@ -405,22 +377,7 @@
         "id": "769GpGCnUdDZ",
         "outputId": "7c73a7dc-51d7-410f-9862-dae99bb11413"
       },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "[Document(metadata={'cmetadata': {'id': 1, 'topic': 'animals', 'location': 'pond'}, 'collection_id': UUID('90462d20-97e5-4094-ba4b-9e2b776938e6')}, page_content='there are cats in the pond'),\n",
-              " Document(metadata={'cmetadata': {'id': 5, 'topic': 'art', 'location': 'museum'}, 'collection_id': UUID('90462d20-97e5-4094-ba4b-9e2b776938e6')}, page_content='the new art exhibit is fascinating'),\n",
-              " Document(metadata={'cmetadata': {'id': 6, 'topic': 'art', 'location': 'museum'}, 'collection_id': UUID('90462d20-97e5-4094-ba4b-9e2b776938e6')}, page_content='a sculpture exhibit is also at the museum'),\n",
-              " Document(metadata={'cmetadata': {'id': 2, 'topic': 'animals', 'location': 'pond'}, 'collection_id': UUID('90462d20-97e5-4094-ba4b-9e2b776938e6')}, page_content='ducks are also found in the pond'),\n",
-              " Document(metadata={'cmetadata': {'id': 9, 'topic': 'reading', 'location': 'library'}, 'collection_id': UUID('90462d20-97e5-4094-ba4b-9e2b776938e6')}, page_content='the library hosts a weekly story time for kids')]"
-            ]
-          },
-          "execution_count": 27,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "# Equivalent PGVector code:\n",
         "# pg_vectorstore.similarity_search(\n",
@@ -453,19 +410,7 @@
         "id": "eVwZdZ35VzZJ",
         "outputId": "20ef5f10-147e-48f5-efe9-685bb74f0af5"
       },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "[Document(metadata={'cmetadata': {'id': 1, 'topic': 'animals', 'location': 'pond'}, 'collection_id': UUID('90462d20-97e5-4094-ba4b-9e2b776938e6')}, page_content='there are cats in the pond'),\n",
-              " Document(metadata={'cmetadata': {'id': 2, 'topic': 'animals', 'location': 'pond'}, 'collection_id': UUID('90462d20-97e5-4094-ba4b-9e2b776938e6')}, page_content='ducks are also found in the pond')]"
-            ]
-          },
-          "execution_count": 29,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "embedding_vectorstore.similarity_search(\n",
         "    \"cats\", k=5, filter=f\"collection_id='{uuid}' and cmetadata->>'topic' = 'animals'\"\n",

--- a/samples/pg_to_alloy_migration_search.ipynb
+++ b/samples/pg_to_alloy_migration_search.ipynb
@@ -256,6 +256,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Note**: This tutorial demonstrates the sync interface. All async methods have corresponding async methods."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -274,8 +281,7 @@
     "id": "5_-kcRf4bJ8B"
    },
    "source": [
-    "Create a connection to your AlloyDB for PostgreSQL instance using the AlloyDBEngine class.\n",
-    "\n"
+    "Create a connection to your AlloyDB for PostgreSQL instance using the AlloyDBEngine class."
    ]
   },
   {
@@ -287,7 +293,6 @@
    "outputs": [],
    "source": [
     "from langchain_google_alloydb_pg import AlloyDBEngine, AlloyDBVectorStore\n",
-    "from langchain_core.documents import Document\n",
     "\n",
     "engine = AlloyDBEngine.from_instance(\n",
     "    project_id=PROJECT_ID,\n",
@@ -303,51 +308,17 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "qI3IdMdubu4y"
-   },
-   "source": [
-    "### Create an embedding class instance\n",
-    "\n",
-    "You can use any [LangChain embeddings model](https://python.langchain.com/docs/integrations/text_embedding/).\n",
-    "You may need to enable Vertex AI API to use `VertexAIEmbeddings`. We recommend setting the embedding model's version for production, learn more about the [Text embeddings models](https://cloud.google.com/vertex-ai/docs/generative-ai/model-reference/text-embeddings)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "vMeZsVuLb_6g"
-   },
-   "outputs": [],
-   "source": [
-    "# enable Vertex AI API\n",
-    "!gcloud services enable aiplatform.googleapis.com"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "69OOOCWebc5X"
-   },
-   "outputs": [],
-   "source": [
-    "from langchain_google_vertexai import VertexAIEmbeddings\n",
-    "\n",
-    "embeddings_service = VertexAIEmbeddings(\n",
-    "    model_name=\"textembedding-gecko@003\", project=PROJECT_ID\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
     "id": "iY8oA59vcL7_"
    },
    "source": [
     "### Initialize an AlloyDB Loader\n",
     "\n",
-    "Intialize an AlloyDB Loader to fetch collection uuid from the \"langchain_pg_collection\" table"
+    "Intialize an AlloyDB Loader to fetch the uuid corresponding to the collection.\n",
+    "\n",
+    "PGvector sets up two tables. \n",
+    "\n",
+    "1. langchain_pg_collection: contains the uuid corresponding to each collection.\n",
+    "2. langchain_pg_embedding: contains documents belonging to all collections."
    ]
   },
   {
@@ -379,7 +350,21 @@
     "id": "5OAU-iFBcISC"
    },
    "source": [
-    "### Initialize an AlloyDBVectorStore on the embeddings data"
+    "### Initialize an AlloyDBVectorStore on the embeddings data\n",
+    "\n",
+    "The PGVector class by default creates a table which contains 4 columns: document, id, cmetadata, collection_id.\n",
+    "\n",
+    "Modify column names if you're using different ones instead."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# enable Vertex AI API\n",
+    "!gcloud services enable aiplatform.googleapis.com"
    ]
   },
   {
@@ -390,14 +375,21 @@
    },
    "outputs": [],
    "source": [
-    "# The PGVector class by default creates a table which contains 4 columns: document, id, cmetadata, collection_id\n",
-    "# Modify column names if you're using different ones instead.\n",
+    "from langchain_google_vertexai import VertexAIEmbeddings\n",
+    "\n",
+    "# In the PGVector class, we initialize using the embeddings variable, \n",
+    "# but AlloyDB interface uses embedding_service.\n",
+    "embedding_service = VertexAIEmbeddings(\n",
+    "    model_name=\"textembedding-gecko@003\", project=PROJECT_ID\n",
+    ")\n",
+    "\n",
     "embedding_vectorstore = AlloyDBVectorStore.create_sync(\n",
     "    engine=engine,\n",
     "    table_name=\"langchain_pg_embedding\",\n",
-    "    embedding_service=embeddings_service,\n",
+    "    embedding_service=embedding_service,\n",
     "    content_column=\"document\",\n",
-    "    metadata_columns=[\"cmetadata\", \"collection_id\"],\n",
+    "    metadata_json_column=\"cmetadata\",\n",
+    "    metadata_columns=[\"collection_id\"],\n",
     "    id_column=\"id\",\n",
     ")"
    ]

--- a/samples/pg_to_alloy_migration_search.ipynb
+++ b/samples/pg_to_alloy_migration_search.ipynb
@@ -1,31 +1,20 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "provenance": []
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "QfhjUMPlX-2t"
+      },
       "source": [
         "# PGVector to AlloyDB Migration\n",
         "Self Link: [go/pg-to-alloy-migration-search](http://go/pg-to-alloy-migration-search)"
-      ],
-      "metadata": {
-        "id": "QfhjUMPlX-2t"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "C5buBYm2WTKV"
+      },
       "source": [
         "## Introduction\n",
         "\n",
@@ -34,13 +23,13 @@
         "This would allow you to migrate from using [PGVector](https://api.python.langchain.com/en/latest/vectorstores/langchain_postgres.vectorstores.PGVector.html#langchain_postgres.vectorstores.PGVector) to [AlloyDB Vector Store](https://github.com/googleapis/langchain-google-alloydb-pg-python/blob/main/docs/vector_store.ipynb) search methods.\n",
         "\n",
         "The AlloyDB interface simplifies secure connections to the AlloyDB database, even for users with little experience.\n"
-      ],
-      "metadata": {
-        "id": "C5buBYm2WTKV"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "TE2CIamaXpqY"
+      },
       "source": [
         "## Before you begin\n",
         "\n",
@@ -51,71 +40,70 @@
         "* [Create a AlloyDB cluster and instance](https://cloud.google.com/alloydb/docs/cluster-create)\n",
         "* [Create a AlloyDB database](https://cloud.google.com/alloydb/docs/quickstart/create-and-connect)\n",
         "* [Add a User to the database](https://cloud.google.com/alloydb/docs/database-users/about)\n"
-      ],
-      "metadata": {
-        "id": "TE2CIamaXpqY"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "  ### 🦜🔗 Library Installation\n",
-        "  Install the integration library, `langchain-google-alloydb-pg`, and the library for the embedding service, `langchain-google-vertexai`."
-      ],
-      "metadata": {
-        "id": "yeFGQ9kPYs0W"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "%pip install --upgrade --quiet  langchain-google-alloydb-pg langchain-google-vertexai"
-      ],
-      "metadata": {
-        "id": "t-FWrCqVH7v5",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "e9e30198-d2ca-4365-b21b-d6ab0eeb0623"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\u001b[?25l   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/2.7 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r\u001b[2K   \u001b[91m━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.8/2.7 MB\u001b[0m \u001b[31m26.0 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r\u001b[2K   \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m2.7/2.7 MB\u001b[0m \u001b[31m50.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m2.7/2.7 MB\u001b[0m \u001b[31m35.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25h"
-          ]
-        }
       ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "**Colab only:** Uncomment the following cell to restart the kernel or use the button to restart the kernel. For Vertex AI Workbench you can restart the terminal using the button on top."
-      ],
       "metadata": {
-        "id": "Mj6qCBI7Y7sh"
-      }
+        "id": "yeFGQ9kPYs0W"
+      },
+      "source": [
+        "  ### 🦜🔗 Library Installation\n",
+        "  Install the integration library, `langchain-google-alloydb-pg`, and the library for the embedding service, `langchain-google-vertexai`."
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "t-FWrCqVH7v5",
+        "outputId": "e9e30198-d2ca-4365-b21b-d6ab0eeb0623"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Note: you may need to restart the kernel to use updated packages.\n"
+          ]
+        }
+      ],
+      "source": [
+        "%pip install --upgrade --quiet  langchain-google-alloydb-pg langchain-google-vertexai"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Mj6qCBI7Y7sh"
+      },
+      "source": [
+        "**Colab only:** Uncomment the following cell to restart the kernel or use the button to restart the kernel. For Vertex AI Workbench you can restart the terminal using the button on top."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {
+        "id": "ziswhCwcY_MV"
+      },
+      "outputs": [],
       "source": [
         "# # Automatically restart kernel after installs so that your environment can access the new packages\n",
         "# import IPython\n",
         "\n",
         "# app = IPython.Application.instance()\n",
         "# app.kernel.do_shutdown(True)"
-      ],
-      "metadata": {
-        "id": "ziswhCwcY_MV"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "tib6qz9QH-Lh"
+      },
       "source": [
         "### 🔐 Authentication\n",
         "Authenticate to Google Cloud as the IAM user logged into this notebook in order to access your Google Cloud Project.\n",
@@ -123,18 +111,27 @@
         "* If you are using Colab to run this notebook, use the cell below and continue.\n",
         "\n",
         "* If you are using Vertex AI Workbench, check out the setup instructions [here](https://github.com/GoogleCloudPlatform/generative-ai/tree/main/setup-env)"
-      ],
-      "metadata": {
-        "id": "tib6qz9QH-Lh"
-      }
+      ]
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 3,
       "metadata": {
         "id": "MLA9smX8OBcM"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "ename": "ModuleNotFoundError",
+          "evalue": "No module named 'google.colab'",
+          "output_type": "error",
+          "traceback": [
+            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+            "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
+            "Cell \u001b[0;32mIn[3], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mgoogle\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mcolab\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m auth\n\u001b[1;32m      3\u001b[0m auth\u001b[38;5;241m.\u001b[39mauthenticate_user()\n",
+            "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'google.colab'"
+          ]
+        }
+      ],
       "source": [
         "from google.colab import auth\n",
         "\n",
@@ -143,6 +140,9 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "92AhND6pIAPY"
+      },
       "source": [
         "  ### ☁ Set Your Google Cloud Project\n",
         "  Set your Google Cloud project so that you can leverage Google Cloud resources within this notebook.\n",
@@ -152,21 +152,11 @@
         "  * Run `gcloud config list`.\n",
         "  * Run `gcloud projects list`.\n",
         "  * See the support page: [Locate the project ID](https://support.google.com/googleapi/answer/7014113)."
-      ],
-      "metadata": {
-        "id": "92AhND6pIAPY"
-      }
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "# @markdown Please fill in the value below with your Google Cloud project ID and then run the cell.\n",
-        "\n",
-        "PROJECT_ID = \"twisha-dev\"  # @param {type:\"string\"}\n",
-        "\n",
-        "# Set the project id\n",
-        "!gcloud config set project {PROJECT_ID}"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -174,54 +164,64 @@
         "id": "TqWdttLHOEsr",
         "outputId": "29fa03ed-de0b-4ac1-95e7-6d33e566e66a"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Updated property [core/project].\n"
           ]
         }
+      ],
+      "source": [
+        "# @markdown Please fill in the value below with your Google Cloud project ID and then run the cell.\n",
+        "\n",
+        "PROJECT_ID = \"twisha-dev\"  # @param {type:\"string\"}\n",
+        "\n",
+        "# Set the project id\n",
+        "!gcloud config set project {PROJECT_ID}"
       ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "## Basic Usage"
-      ],
       "metadata": {
         "id": "NqeEeQc6Z137"
-      }
+      },
+      "source": [
+        "## Basic Usage"
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "pAfvCrs1Z2Le"
+      },
       "source": [
         "### Set AlloyDB database values\n",
         "\n",
         "Find your database values, in the [AlloyDB Instances page](https://console.cloud.google.com/alloydb/clusters)."
-      ],
-      "metadata": {
-        "id": "pAfvCrs1Z2Le"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "A3BYZXQrOsQP"
+      },
+      "outputs": [],
       "source": [
         "# @title Set Your Values Here { display-mode: \"form\" }\n",
         "REGION = \"us-central1\"  # @param {type: \"string\"}\n",
         "CLUSTER = \"twisha-dev-cluster\"  # @param {type: \"string\"}\n",
         "INSTANCE = \"my-primary\"  # @param {type: \"string\"}\n",
         "DATABASE = \"test_db\"  # @param {type: \"string\"}"
-      ],
-      "metadata": {
-        "id": "A3BYZXQrOsQP"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "dS3X75KpabxA"
+      },
       "source": [
         "### AlloyDBEngine Connection Pool\n",
         "\n",
@@ -242,36 +242,38 @@
         "\n",
         "* `user` : Database user to use for built-in database authentication and login.\n",
         "* `password` : Database password to use for built-in database authentication and login."
-      ],
-      "metadata": {
-        "id": "dS3X75KpabxA"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "HPcWWr_LaLqD"
+      },
+      "outputs": [],
       "source": [
         "# @title Set Your Values Here { display-mode: \"form\" }\n",
         "USER = \"postgres\"  # @param {type: \"string\"}\n",
         "PASSWORD = \"alloydb\"  # @param {type: \"string\"}"
-      ],
-      "metadata": {
-        "id": "HPcWWr_LaLqD"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "5_-kcRf4bJ8B"
+      },
       "source": [
         "Create a connection to your AlloyDB for PostgreSQL instance using the AlloyDBEngine class.\n",
         "\n"
-      ],
-      "metadata": {
-        "id": "5_-kcRf4bJ8B"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "rWlcGt3JIDIy"
+      },
+      "outputs": [],
       "source": [
         "from langchain_google_alloydb_pg import AlloyDBEngine, AlloyDBVectorStore, Column\n",
         "from langchain_core.documents import Document\n",
@@ -286,65 +288,65 @@
         "    user=USER,\n",
         "    password=PASSWORD,\n",
         ")"
-      ],
-      "metadata": {
-        "id": "rWlcGt3JIDIy"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "qI3IdMdubu4y"
+      },
       "source": [
         "### Create an embedding class instance\n",
         "\n",
         "You can use any [LangChain embeddings model](https://python.langchain.com/docs/integrations/text_embedding/).\n",
         "You may need to enable Vertex AI API to use `VertexAIEmbeddings`. We recommend setting the embedding model's version for production, learn more about the [Text embeddings models](https://cloud.google.com/vertex-ai/docs/generative-ai/model-reference/text-embeddings)."
-      ],
-      "metadata": {
-        "id": "qI3IdMdubu4y"
-      }
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "# enable Vertex AI API\n",
-        "!gcloud services enable aiplatform.googleapis.com"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "vMeZsVuLb_6g"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "# enable Vertex AI API\n",
+        "!gcloud services enable aiplatform.googleapis.com"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "69OOOCWebc5X"
+      },
+      "outputs": [],
       "source": [
         "from langchain_google_vertexai import VertexAIEmbeddings\n",
         "\n",
         "embeddings_service = VertexAIEmbeddings(\n",
         "    model_name=\"textembedding-gecko@003\", project=PROJECT_ID\n",
         ")"
-      ],
-      "metadata": {
-        "id": "69OOOCWebc5X"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "iY8oA59vcL7_"
+      },
       "source": [
         "### Initialize an AlloyDB Loader\n",
         "\n",
         "Intialize an AlloyDB Loader to fetch collection uuid from the \"langchain_pg_collection\" table"
-      ],
-      "metadata": {
-        "id": "iY8oA59vcL7_"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "phMW5OS1IOA9"
+      },
+      "outputs": [],
       "source": [
         "from langchain_google_alloydb_pg import AlloyDBLoader\n",
         "\n",
@@ -355,24 +357,24 @@
         ")\n",
         "doc = collection_loader.load()\n",
         "uuid = doc[0].page_content"
-      ],
-      "metadata": {
-        "id": "phMW5OS1IOA9"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### Initialize an AlloyDBVectorStore on the embeddings data"
-      ],
       "metadata": {
         "id": "5OAU-iFBcISC"
-      }
+      },
+      "source": [
+        "### Initialize an AlloyDBVectorStore on the embeddings data"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "fE3U6VKRIdst"
+      },
+      "outputs": [],
       "source": [
         "embedding_vectorstore = AlloyDBVectorStore.create_sync(\n",
         "    engine=engine,\n",
@@ -382,34 +384,20 @@
         "    metadata_columns=[\"cmetadata\", \"collection_id\"],\n",
         "    id_column=\"id\",\n",
         ")"
-      ],
-      "metadata": {
-        "id": "fE3U6VKRIdst"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### Perform basic similarity search"
-      ],
       "metadata": {
         "id": "L9uA3d_tckNT"
-      }
+      },
+      "source": [
+        "### Perform basic similarity search"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "# Equivalent PGVector code:\n",
-        "# pg_vectorstore.similarity_search(\n",
-        "#     \"cats\", k=5\n",
-        "# )\n",
-        "\n",
-        "embedding_vectorstore.similarity_search(\n",
-        "    \"cats\", k=5, filter=f\"collection_id='{uuid}'\"\n",
-        ")"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -417,10 +405,8 @@
         "id": "769GpGCnUdDZ",
         "outputId": "7c73a7dc-51d7-410f-9862-dae99bb11413"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "[Document(metadata={'cmetadata': {'id': 1, 'topic': 'animals', 'location': 'pond'}, 'collection_id': UUID('90462d20-97e5-4094-ba4b-9e2b776938e6')}, page_content='there are cats in the pond'),\n",
@@ -430,29 +416,36 @@
               " Document(metadata={'cmetadata': {'id': 9, 'topic': 'reading', 'location': 'library'}, 'collection_id': UUID('90462d20-97e5-4094-ba4b-9e2b776938e6')}, page_content='the library hosts a weekly story time for kids')]"
             ]
           },
+          "execution_count": 27,
           "metadata": {},
-          "execution_count": 27
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Equivalent PGVector code:\n",
+        "# pg_vectorstore.similarity_search(\n",
+        "#     \"cats\", k=5\n",
+        "# )\n",
+        "\n",
+        "embedding_vectorstore.similarity_search(\n",
+        "    \"cats\", k=5, filter=f\"collection_id='{uuid}'\"\n",
+        ")"
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "Ux6KNk3Tcn2x"
+      },
       "source": [
         "### Perform similarity search with metadata filters\n",
         "\n",
         "The filter should be written using SQL syntax as it forms part of the WHERE clause in your query."
-      ],
-      "metadata": {
-        "id": "Ux6KNk3Tcn2x"
-      }
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "embedding_vectorstore.similarity_search(\n",
-        "    \"cats\", k=5, filter=f\"collection_id='{uuid}' and cmetadata->>'topic' = 'animals'\"\n",
-        ")"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -460,20 +453,47 @@
         "id": "eVwZdZ35VzZJ",
         "outputId": "20ef5f10-147e-48f5-efe9-685bb74f0af5"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "[Document(metadata={'cmetadata': {'id': 1, 'topic': 'animals', 'location': 'pond'}, 'collection_id': UUID('90462d20-97e5-4094-ba4b-9e2b776938e6')}, page_content='there are cats in the pond'),\n",
               " Document(metadata={'cmetadata': {'id': 2, 'topic': 'animals', 'location': 'pond'}, 'collection_id': UUID('90462d20-97e5-4094-ba4b-9e2b776938e6')}, page_content='ducks are also found in the pond')]"
             ]
           },
+          "execution_count": 29,
           "metadata": {},
-          "execution_count": 29
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "embedding_vectorstore.similarity_search(\n",
+        "    \"cats\", k=5, filter=f\"collection_id='{uuid}' and cmetadata->>'topic' = 'animals'\"\n",
+        ")"
       ]
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.8.16"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/samples/pg_to_alloy_migration_search.ipynb
+++ b/samples/pg_to_alloy_migration_search.ipynb
@@ -27,7 +27,7 @@
     "id": "QfhjUMPlX-2t"
    },
    "source": [
-    "# PGVector to AlloyDB Migration\n"
+    "# Migrate a PGVector vector store to AlloyDBVectorStore\n"
    ]
   },
   {

--- a/samples/pg_to_alloy_migration_search.ipynb
+++ b/samples/pg_to_alloy_migration_search.ipynb
@@ -385,7 +385,7 @@
     "# Choose the collection to perform vector search on\n",
     "collection_name = \"test_table\"\n",
     "\n",
-    "# The langchain_pg_collection table usually stores collection-to-UUID mappings. \n",
+    "# The langchain_pg_collection table usually stores collection-to-UUID mappings.\n",
     "# Modify the name if you're using a different table.\n",
     "collection_loader = AlloyDBLoader.create_sync(\n",
     "    engine=engine,\n",

--- a/samples/pg_to_alloy_migration_search.ipynb
+++ b/samples/pg_to_alloy_migration_search.ipynb
@@ -1,13 +1,33 @@
 {
  "cells": [
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Copyright 2024 Google LLC\n",
+    "#\n",
+    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "#     https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {
     "id": "QfhjUMPlX-2t"
    },
    "source": [
-    "# PGVector to AlloyDB Migration\n",
-    "Self Link: [go/pg-to-alloy-migration-search](http://go/pg-to-alloy-migration-search)"
+    "# PGVector to AlloyDB Migration\n"
    ]
   },
   {
@@ -16,6 +36,10 @@
     "id": "C5buBYm2WTKV"
    },
    "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/googleapis/langchain-google-alloydb-pg-python/blob/main/samples/pg_to_alloy_migration_search.ipynb)\n",
+    "\n",
+    "---\n",
+    "\n",
     "## Introduction\n",
     "\n",
     "In this codelab, you'll learn how to use AlloyDB interface for vector search in any DB created using the PGVector interface.\n",
@@ -54,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -62,7 +86,15 @@
     "id": "t-FWrCqVH7v5",
     "outputId": "e9e30198-d2ca-4365-b21b-d6ab0eeb0623"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
    "source": [
     "%pip install --upgrade --quiet  langchain-google-alloydb-pg langchain-google-vertexai"
    ]
@@ -78,7 +110,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {
     "id": "ziswhCwcY_MV"
    },
@@ -107,11 +139,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {
     "id": "MLA9smX8OBcM"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "ModuleNotFoundError",
+     "evalue": "No module named 'google.colab'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[9], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mgoogle\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mcolab\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m auth\n\u001b[1;32m      3\u001b[0m auth\u001b[38;5;241m.\u001b[39mauthenticate_user()\n",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'google.colab'"
+     ]
+    }
+   ],
    "source": [
     "from google.colab import auth\n",
     "\n",
@@ -146,11 +190,15 @@
    },
    "outputs": [],
    "source": [
-    "# @markdown Please fill in the value below with your Google Cloud project ID and then run the cell.\n",
+    "# @markdown Please fill in the value below with your GCP project ID and then run the cell.\n",
     "\n",
-    "PROJECT_ID = \"twisha-dev\"  # @param {type:\"string\"}\n",
+    "# Please fill in these values.\n",
+    "PROJECT_ID = \"\"  # @param {type:\"string\"}\n",
     "\n",
-    "# Set the project id\n",
+    "# Quick input validations.\n",
+    "assert PROJECT_ID, \"⚠️ Please provide a Google Cloud project ID\"\n",
+    "\n",
+    "# Configure gcloud.\n",
     "!gcloud config set project {PROJECT_ID}"
    ]
   },
@@ -182,11 +230,24 @@
    },
    "outputs": [],
    "source": [
-    "# @title Set Your Values Here { display-mode: \"form\" }\n",
-    "REGION = \"us-central1\"  # @param {type: \"string\"}\n",
-    "CLUSTER = \"twisha-dev-cluster\"  # @param {type: \"string\"}\n",
-    "INSTANCE = \"my-primary\"  # @param {type: \"string\"}\n",
-    "DATABASE = \"test_db\"  # @param {type: \"string\"}"
+    "# @markdown Please fill in these values.\n",
+    "REGION = \"\"  # @param {type:\"string\"}\n",
+    "CLUSTER = \"\"  # @param {type:\"string\"}\n",
+    "INSTANCE = \"\"  # @param {type:\"string\"}\n",
+    "DATABASE = \"\"  # @param {type:\"string\"}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Quick input validations.\n",
+    "assert REGION, \"⚠️ Please provide a Google Cloud region\"\n",
+    "assert INSTANCE, \"⚠️ Please provide the name of your instance\"\n",
+    "assert DATABASE, \"⚠️ Please provide the name of your database_name\"\n",
+    "assert CLUSTER, \"⚠️ Please provide the name of your alloydb cluster\""
    ]
   },
   {
@@ -226,7 +287,7 @@
    "source": [
     "# @title Set Your Values Here { display-mode: \"form\" }\n",
     "USER = \"postgres\"  # @param {type: \"string\"}\n",
-    "PASSWORD = \"alloydb\"  # @param {type: \"string\"}"
+    "PASSWORD = input(f\"Please provide a password to be used for {USER} database user: \")"
    ]
   },
   {
@@ -247,9 +308,8 @@
    },
    "outputs": [],
    "source": [
-    "from langchain_google_alloydb_pg import AlloyDBEngine, AlloyDBVectorStore, Column\n",
+    "from langchain_google_alloydb_pg import AlloyDBEngine, AlloyDBVectorStore\n",
     "from langchain_core.documents import Document\n",
-    "import uuid\n",
     "\n",
     "engine = AlloyDBEngine.from_instance(\n",
     "    project_id=PROJECT_ID,\n",
@@ -322,7 +382,11 @@
    "source": [
     "from langchain_google_alloydb_pg import AlloyDBLoader\n",
     "\n",
+    "# Choose the collection to perform vector search on\n",
     "collection_name = \"test_table\"\n",
+    "\n",
+    "# The langchain_pg_collection table usually stores collection-to-UUID mappings. \n",
+    "# Modify the name if you're using a different table.\n",
     "collection_loader = AlloyDBLoader.create_sync(\n",
     "    engine=engine,\n",
     "    query=f\"SELECT * from langchain_pg_collection WHERE name='{collection_name}'\",\n",
@@ -348,6 +412,8 @@
    },
    "outputs": [],
    "source": [
+    "# The PGVector class by default creates a table which contains 4 columns: document, id, cmetadata, collection_id\n",
+    "# Modify column names if you're using different ones instead.\n",
     "embedding_vectorstore = AlloyDBVectorStore.create_sync(\n",
     "    engine=engine,\n",
     "    table_name=\"langchain_pg_embedding\",\n",

--- a/samples/pg_to_alloy_migration_search.ipynb
+++ b/samples/pg_to_alloy_migration_search.ipynb
@@ -377,7 +377,7 @@
    "source": [
     "from langchain_google_vertexai import VertexAIEmbeddings\n",
     "\n",
-    "# In the PGVector class, we initialize using the embeddings variable, \n",
+    "# In the PGVector class, we initialize using the embeddings variable,\n",
     "# but AlloyDB interface uses embedding_service.\n",
     "embedding_service = VertexAIEmbeddings(\n",
     "    model_name=\"textembedding-gecko@003\", project=PROJECT_ID\n",

--- a/samples/pg_to_alloy_migration_search.ipynb
+++ b/samples/pg_to_alloy_migration_search.ipynb
@@ -44,9 +44,7 @@
     "\n",
     "In this notebook, you'll learn how to use the AlloyDBVectorStore interface for vector search from vector stores created when using the PGVector interface.\n",
     "\n",
-    "This would allow you to migrate from using [PGVector](https://api.python.langchain.com/en/latest/vectorstores/langchain_postgres.vectorstores.PGVector.html#langchain_postgres.vectorstores.PGVector) to [AlloyDB Vector Store](https://github.com/googleapis/langchain-google-alloydb-pg-python/blob/main/docs/vector_store.ipynb) search methods.\n",
-    "\n",
-    "The AlloyDB interface simplifies secure connections to the AlloyDB database, even for users with little experience.\n"
+    "This will allow you to migrate from the [`PGVector` interface](https://api.python.langchain.com/en/latest/vectorstores/langchain_postgres.vectorstores.PGVector.html#langchain_postgres.vectorstores.PGVector) to the [`AlloyDBVectorStore` interface](https://github.com/googleapis/langchain-google-alloydb-pg-python/blob/main/docs/vector_store.ipynb) and benefit from secure database connections and authentication, improve metadata handling, and advanced vector indexes.\n"
    ]
   },
   {

--- a/samples/pg_to_alloy_migration_search.ipynb
+++ b/samples/pg_to_alloy_migration_search.ipynb
@@ -1,444 +1,442 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "QfhjUMPlX-2t"
-      },
-      "source": [
-        "# PGVector to AlloyDB Migration\n",
-        "Self Link: [go/pg-to-alloy-migration-search](http://go/pg-to-alloy-migration-search)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "C5buBYm2WTKV"
-      },
-      "source": [
-        "## Introduction\n",
-        "\n",
-        "In this codelab, you'll learn how to use AlloyDB interface for vector search in any DB created using the PGVector interface.\n",
-        "\n",
-        "This would allow you to migrate from using [PGVector](https://api.python.langchain.com/en/latest/vectorstores/langchain_postgres.vectorstores.PGVector.html#langchain_postgres.vectorstores.PGVector) to [AlloyDB Vector Store](https://github.com/googleapis/langchain-google-alloydb-pg-python/blob/main/docs/vector_store.ipynb) search methods.\n",
-        "\n",
-        "The AlloyDB interface simplifies secure connections to the AlloyDB database, even for users with little experience.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "TE2CIamaXpqY"
-      },
-      "source": [
-        "## Before you begin\n",
-        "\n",
-        "This notebook assumes that you have done the following:\n",
-        "\n",
-        "* [Create a Google Cloud Project](https://developers.google.com/workspace/guides/create-project)\n",
-        "* [Enable the AlloyDB API](https://console.cloud.google.com/flows/enableapi?apiid=alloydb.googleapis.com)\n",
-        "* [Create a AlloyDB cluster and instance](https://cloud.google.com/alloydb/docs/cluster-create)\n",
-        "* [Create a AlloyDB database](https://cloud.google.com/alloydb/docs/quickstart/create-and-connect)\n",
-        "* [Add a User to the database](https://cloud.google.com/alloydb/docs/database-users/about)\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "yeFGQ9kPYs0W"
-      },
-      "source": [
-        "  ### 🦜🔗 Library Installation\n",
-        "  Install the integration library, `langchain-google-alloydb-pg`, and the library for the embedding service, `langchain-google-vertexai`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "t-FWrCqVH7v5",
-        "outputId": "e9e30198-d2ca-4365-b21b-d6ab0eeb0623"
-      },
-      "outputs": [],
-      "source": [
-        "%pip install --upgrade --quiet  langchain-google-alloydb-pg langchain-google-vertexai"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Mj6qCBI7Y7sh"
-      },
-      "source": [
-        "**Colab only:** Uncomment the following cell to restart the kernel or use the button to restart the kernel. For Vertex AI Workbench you can restart the terminal using the button on top."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "ziswhCwcY_MV"
-      },
-      "outputs": [],
-      "source": [
-        "# # Automatically restart kernel after installs so that your environment can access the new packages\n",
-        "# import IPython\n",
-        "\n",
-        "# app = IPython.Application.instance()\n",
-        "# app.kernel.do_shutdown(True)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "tib6qz9QH-Lh"
-      },
-      "source": [
-        "### 🔐 Authentication\n",
-        "Authenticate to Google Cloud as the IAM user logged into this notebook in order to access your Google Cloud Project.\n",
-        "\n",
-        "* If you are using Colab to run this notebook, use the cell below and continue.\n",
-        "\n",
-        "* If you are using Vertex AI Workbench, check out the setup instructions [here](https://github.com/GoogleCloudPlatform/generative-ai/tree/main/setup-env)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "MLA9smX8OBcM"
-      },
-      "outputs": [],
-      "source": [
-        "from google.colab import auth\n",
-        "\n",
-        "auth.authenticate_user()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "92AhND6pIAPY"
-      },
-      "source": [
-        "  ### ☁ Set Your Google Cloud Project\n",
-        "  Set your Google Cloud project so that you can leverage Google Cloud resources within this notebook.\n",
-        "  \n",
-        "  If you don't know your project ID, try the following:\n",
-        "\n",
-        "  * Run `gcloud config list`.\n",
-        "  * Run `gcloud projects list`.\n",
-        "  * See the support page: [Locate the project ID](https://support.google.com/googleapi/answer/7014113)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "TqWdttLHOEsr",
-        "outputId": "29fa03ed-de0b-4ac1-95e7-6d33e566e66a"
-      },
-      "outputs": [],
-      "source": [
-        "# @markdown Please fill in the value below with your Google Cloud project ID and then run the cell.\n",
-        "\n",
-        "PROJECT_ID = \"twisha-dev\"  # @param {type:\"string\"}\n",
-        "\n",
-        "# Set the project id\n",
-        "!gcloud config set project {PROJECT_ID}"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "NqeEeQc6Z137"
-      },
-      "source": [
-        "## Basic Usage"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "pAfvCrs1Z2Le"
-      },
-      "source": [
-        "### Set AlloyDB database values\n",
-        "\n",
-        "Find your database values, in the [AlloyDB Instances page](https://console.cloud.google.com/alloydb/clusters)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "A3BYZXQrOsQP"
-      },
-      "outputs": [],
-      "source": [
-        "# @title Set Your Values Here { display-mode: \"form\" }\n",
-        "REGION = \"us-central1\"  # @param {type: \"string\"}\n",
-        "CLUSTER = \"twisha-dev-cluster\"  # @param {type: \"string\"}\n",
-        "INSTANCE = \"my-primary\"  # @param {type: \"string\"}\n",
-        "DATABASE = \"test_db\"  # @param {type: \"string\"}"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "dS3X75KpabxA"
-      },
-      "source": [
-        "### AlloyDBEngine Connection Pool\n",
-        "\n",
-        "One of the requirements and arguments to establish AlloyDB as a vector store is a `AlloyDBEngine` object. The `AlloyDBEngine`  configures a connection pool to your AlloyDB database, enabling successful connections from your application and following industry best practices.\n",
-        "\n",
-        "To create a `AlloyDBEngine` using `AlloyDBEngine.from_instance()` you need to provide only 5 things:\n",
-        "\n",
-        "1. `project_id` : Project ID of the Google Cloud Project where the AlloyDB instance is located.\n",
-        "2. `region` : Region where the AlloyDB instance is located.\n",
-        "3. `cluster`: The name of the AlloyDB cluster.\n",
-        "4. `instance` : The name of the AlloyDB instance.\n",
-        "5. `database` : The name of the database to connect to on the AlloyDB instance.\n",
-        "\n",
-        "\n",
-        "By default, [IAM database authentication](https://cloud.google.com/alloydb/docs/connect-iam) will be used as the method of database authentication. This library uses the IAM principal belonging to the [Application Default Credentials (ADC)](https://cloud.google.com/docs/authentication/application-default-credentials) sourced from the environment.\n",
-        "\n",
-        "Optionally, [built-in database authentication](https://cloud.google.com/alloydb/docs/database-users/about) using a username and password to access the AlloyDB database can also be used. Just provide the optional `user` and `password` arguments to `AlloyDBEngine.from_instance()`:\n",
-        "\n",
-        "* `user` : Database user to use for built-in database authentication and login.\n",
-        "* `password` : Database password to use for built-in database authentication and login."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "HPcWWr_LaLqD"
-      },
-      "outputs": [],
-      "source": [
-        "# @title Set Your Values Here { display-mode: \"form\" }\n",
-        "USER = \"postgres\"  # @param {type: \"string\"}\n",
-        "PASSWORD = \"alloydb\"  # @param {type: \"string\"}"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "5_-kcRf4bJ8B"
-      },
-      "source": [
-        "Create a connection to your AlloyDB for PostgreSQL instance using the AlloyDBEngine class.\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "rWlcGt3JIDIy"
-      },
-      "outputs": [],
-      "source": [
-        "from langchain_google_alloydb_pg import AlloyDBEngine, AlloyDBVectorStore, Column\n",
-        "from langchain_core.documents import Document\n",
-        "import uuid\n",
-        "\n",
-        "engine = AlloyDBEngine.from_instance(\n",
-        "    project_id=PROJECT_ID,\n",
-        "    region=REGION,\n",
-        "    cluster=CLUSTER,\n",
-        "    instance=INSTANCE,\n",
-        "    database=DATABASE,\n",
-        "    user=USER,\n",
-        "    password=PASSWORD,\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "qI3IdMdubu4y"
-      },
-      "source": [
-        "### Create an embedding class instance\n",
-        "\n",
-        "You can use any [LangChain embeddings model](https://python.langchain.com/docs/integrations/text_embedding/).\n",
-        "You may need to enable Vertex AI API to use `VertexAIEmbeddings`. We recommend setting the embedding model's version for production, learn more about the [Text embeddings models](https://cloud.google.com/vertex-ai/docs/generative-ai/model-reference/text-embeddings)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "vMeZsVuLb_6g"
-      },
-      "outputs": [],
-      "source": [
-        "# enable Vertex AI API\n",
-        "!gcloud services enable aiplatform.googleapis.com"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "69OOOCWebc5X"
-      },
-      "outputs": [],
-      "source": [
-        "from langchain_google_vertexai import VertexAIEmbeddings\n",
-        "\n",
-        "embeddings_service = VertexAIEmbeddings(\n",
-        "    model_name=\"textembedding-gecko@003\", project=PROJECT_ID\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "iY8oA59vcL7_"
-      },
-      "source": [
-        "### Initialize an AlloyDB Loader\n",
-        "\n",
-        "Intialize an AlloyDB Loader to fetch collection uuid from the \"langchain_pg_collection\" table"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "phMW5OS1IOA9"
-      },
-      "outputs": [],
-      "source": [
-        "from langchain_google_alloydb_pg import AlloyDBLoader\n",
-        "\n",
-        "collection_name = \"test_table\"\n",
-        "collection_loader = AlloyDBLoader.create_sync(\n",
-        "    engine=engine,\n",
-        "    query=f\"SELECT * from langchain_pg_collection WHERE name='{collection_name}'\"\n",
-        ")\n",
-        "doc = collection_loader.load()\n",
-        "uuid = doc[0].page_content"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "5OAU-iFBcISC"
-      },
-      "source": [
-        "### Initialize an AlloyDBVectorStore on the embeddings data"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "fE3U6VKRIdst"
-      },
-      "outputs": [],
-      "source": [
-        "embedding_vectorstore = AlloyDBVectorStore.create_sync(\n",
-        "    engine=engine,\n",
-        "    table_name=\"langchain_pg_embedding\",\n",
-        "    embedding_service=embeddings_service,\n",
-        "    content_column=\"document\",\n",
-        "    metadata_columns=[\"cmetadata\", \"collection_id\"],\n",
-        "    id_column=\"id\",\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "L9uA3d_tckNT"
-      },
-      "source": [
-        "### Perform basic similarity search"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "769GpGCnUdDZ",
-        "outputId": "7c73a7dc-51d7-410f-9862-dae99bb11413"
-      },
-      "outputs": [],
-      "source": [
-        "# Equivalent PGVector code:\n",
-        "# pg_vectorstore.similarity_search(\n",
-        "#     \"cats\", k=5\n",
-        "# )\n",
-        "\n",
-        "embedding_vectorstore.similarity_search(\n",
-        "    \"cats\", k=5, filter=f\"collection_id='{uuid}'\"\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Ux6KNk3Tcn2x"
-      },
-      "source": [
-        "### Perform similarity search with metadata filters\n",
-        "\n",
-        "The filter should be written using SQL syntax as it forms part of the WHERE clause in your query."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "eVwZdZ35VzZJ",
-        "outputId": "20ef5f10-147e-48f5-efe9-685bb74f0af5"
-      },
-      "outputs": [],
-      "source": [
-        "embedding_vectorstore.similarity_search(\n",
-        "    \"cats\", k=5, filter=f\"collection_id='{uuid}' and cmetadata->>'topic' = 'animals'\"\n",
-        ")"
-      ]
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "provenance": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.8.16"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "QfhjUMPlX-2t"
+   },
+   "source": [
+    "# PGVector to AlloyDB Migration\n",
+    "Self Link: [go/pg-to-alloy-migration-search](http://go/pg-to-alloy-migration-search)"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "C5buBYm2WTKV"
+   },
+   "source": [
+    "## Introduction\n",
+    "\n",
+    "In this codelab, you'll learn how to use AlloyDB interface for vector search in any DB created using the PGVector interface.\n",
+    "\n",
+    "This would allow you to migrate from using [PGVector](https://api.python.langchain.com/en/latest/vectorstores/langchain_postgres.vectorstores.PGVector.html#langchain_postgres.vectorstores.PGVector) to [AlloyDB Vector Store](https://github.com/googleapis/langchain-google-alloydb-pg-python/blob/main/docs/vector_store.ipynb) search methods.\n",
+    "\n",
+    "The AlloyDB interface simplifies secure connections to the AlloyDB database, even for users with little experience.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "TE2CIamaXpqY"
+   },
+   "source": [
+    "## Before you begin\n",
+    "\n",
+    "This notebook assumes that you have done the following:\n",
+    "\n",
+    "* [Create a Google Cloud Project](https://developers.google.com/workspace/guides/create-project)\n",
+    "* [Enable the AlloyDB API](https://console.cloud.google.com/flows/enableapi?apiid=alloydb.googleapis.com)\n",
+    "* [Create a AlloyDB cluster and instance](https://cloud.google.com/alloydb/docs/cluster-create)\n",
+    "* [Create a AlloyDB database](https://cloud.google.com/alloydb/docs/quickstart/create-and-connect)\n",
+    "* [Add a User to the database](https://cloud.google.com/alloydb/docs/database-users/about)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "yeFGQ9kPYs0W"
+   },
+   "source": [
+    "  ### 🦜🔗 Library Installation\n",
+    "  Install the integration library, `langchain-google-alloydb-pg`, and the library for the embedding service, `langchain-google-vertexai`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "t-FWrCqVH7v5",
+    "outputId": "e9e30198-d2ca-4365-b21b-d6ab0eeb0623"
+   },
+   "outputs": [],
+   "source": [
+    "%pip install --upgrade --quiet  langchain-google-alloydb-pg langchain-google-vertexai"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Mj6qCBI7Y7sh"
+   },
+   "source": [
+    "**Colab only:** Uncomment the following cell to restart the kernel or use the button to restart the kernel. For Vertex AI Workbench you can restart the terminal using the button on top."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "ziswhCwcY_MV"
+   },
+   "outputs": [],
+   "source": [
+    "# # Automatically restart kernel after installs so that your environment can access the new packages\n",
+    "# import IPython\n",
+    "\n",
+    "# app = IPython.Application.instance()\n",
+    "# app.kernel.do_shutdown(True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "tib6qz9QH-Lh"
+   },
+   "source": [
+    "### 🔐 Authentication\n",
+    "Authenticate to Google Cloud as the IAM user logged into this notebook in order to access your Google Cloud Project.\n",
+    "\n",
+    "* If you are using Colab to run this notebook, use the cell below and continue.\n",
+    "\n",
+    "* If you are using Vertex AI Workbench, check out the setup instructions [here](https://github.com/GoogleCloudPlatform/generative-ai/tree/main/setup-env)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "MLA9smX8OBcM"
+   },
+   "outputs": [],
+   "source": [
+    "from google.colab import auth\n",
+    "\n",
+    "auth.authenticate_user()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "92AhND6pIAPY"
+   },
+   "source": [
+    "  ### ☁ Set Your Google Cloud Project\n",
+    "  Set your Google Cloud project so that you can leverage Google Cloud resources within this notebook.\n",
+    "  \n",
+    "  If you don't know your project ID, try the following:\n",
+    "\n",
+    "  * Run `gcloud config list`.\n",
+    "  * Run `gcloud projects list`.\n",
+    "  * See the support page: [Locate the project ID](https://support.google.com/googleapi/answer/7014113)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "TqWdttLHOEsr",
+    "outputId": "29fa03ed-de0b-4ac1-95e7-6d33e566e66a"
+   },
+   "outputs": [],
+   "source": [
+    "# @markdown Please fill in the value below with your Google Cloud project ID and then run the cell.\n",
+    "\n",
+    "PROJECT_ID = \"twisha-dev\"  # @param {type:\"string\"}\n",
+    "\n",
+    "# Set the project id\n",
+    "!gcloud config set project {PROJECT_ID}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "NqeEeQc6Z137"
+   },
+   "source": [
+    "## Basic Usage"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "pAfvCrs1Z2Le"
+   },
+   "source": [
+    "### Set AlloyDB database values\n",
+    "\n",
+    "Find your database values, in the [AlloyDB Instances page](https://console.cloud.google.com/alloydb/clusters)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "A3BYZXQrOsQP"
+   },
+   "outputs": [],
+   "source": [
+    "# @title Set Your Values Here { display-mode: \"form\" }\n",
+    "REGION = \"us-central1\"  # @param {type: \"string\"}\n",
+    "CLUSTER = \"twisha-dev-cluster\"  # @param {type: \"string\"}\n",
+    "INSTANCE = \"my-primary\"  # @param {type: \"string\"}\n",
+    "DATABASE = \"test_db\"  # @param {type: \"string\"}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "dS3X75KpabxA"
+   },
+   "source": [
+    "### AlloyDBEngine Connection Pool\n",
+    "\n",
+    "One of the requirements and arguments to establish AlloyDB as a vector store is a `AlloyDBEngine` object. The `AlloyDBEngine`  configures a connection pool to your AlloyDB database, enabling successful connections from your application and following industry best practices.\n",
+    "\n",
+    "To create a `AlloyDBEngine` using `AlloyDBEngine.from_instance()` you need to provide only 5 things:\n",
+    "\n",
+    "1. `project_id` : Project ID of the Google Cloud Project where the AlloyDB instance is located.\n",
+    "2. `region` : Region where the AlloyDB instance is located.\n",
+    "3. `cluster`: The name of the AlloyDB cluster.\n",
+    "4. `instance` : The name of the AlloyDB instance.\n",
+    "5. `database` : The name of the database to connect to on the AlloyDB instance.\n",
+    "\n",
+    "\n",
+    "By default, [IAM database authentication](https://cloud.google.com/alloydb/docs/connect-iam) will be used as the method of database authentication. This library uses the IAM principal belonging to the [Application Default Credentials (ADC)](https://cloud.google.com/docs/authentication/application-default-credentials) sourced from the environment.\n",
+    "\n",
+    "Optionally, [built-in database authentication](https://cloud.google.com/alloydb/docs/database-users/about) using a username and password to access the AlloyDB database can also be used. Just provide the optional `user` and `password` arguments to `AlloyDBEngine.from_instance()`:\n",
+    "\n",
+    "* `user` : Database user to use for built-in database authentication and login.\n",
+    "* `password` : Database password to use for built-in database authentication and login."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "HPcWWr_LaLqD"
+   },
+   "outputs": [],
+   "source": [
+    "# @title Set Your Values Here { display-mode: \"form\" }\n",
+    "USER = \"postgres\"  # @param {type: \"string\"}\n",
+    "PASSWORD = \"alloydb\"  # @param {type: \"string\"}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "5_-kcRf4bJ8B"
+   },
+   "source": [
+    "Create a connection to your AlloyDB for PostgreSQL instance using the AlloyDBEngine class.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "rWlcGt3JIDIy"
+   },
+   "outputs": [],
+   "source": [
+    "from langchain_google_alloydb_pg import AlloyDBEngine, AlloyDBVectorStore, Column\n",
+    "from langchain_core.documents import Document\n",
+    "import uuid\n",
+    "\n",
+    "engine = AlloyDBEngine.from_instance(\n",
+    "    project_id=PROJECT_ID,\n",
+    "    region=REGION,\n",
+    "    cluster=CLUSTER,\n",
+    "    instance=INSTANCE,\n",
+    "    database=DATABASE,\n",
+    "    user=USER,\n",
+    "    password=PASSWORD,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "qI3IdMdubu4y"
+   },
+   "source": [
+    "### Create an embedding class instance\n",
+    "\n",
+    "You can use any [LangChain embeddings model](https://python.langchain.com/docs/integrations/text_embedding/).\n",
+    "You may need to enable Vertex AI API to use `VertexAIEmbeddings`. We recommend setting the embedding model's version for production, learn more about the [Text embeddings models](https://cloud.google.com/vertex-ai/docs/generative-ai/model-reference/text-embeddings)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "vMeZsVuLb_6g"
+   },
+   "outputs": [],
+   "source": [
+    "# enable Vertex AI API\n",
+    "!gcloud services enable aiplatform.googleapis.com"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "69OOOCWebc5X"
+   },
+   "outputs": [],
+   "source": [
+    "from langchain_google_vertexai import VertexAIEmbeddings\n",
+    "\n",
+    "embeddings_service = VertexAIEmbeddings(\n",
+    "    model_name=\"textembedding-gecko@003\", project=PROJECT_ID\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "iY8oA59vcL7_"
+   },
+   "source": [
+    "### Initialize an AlloyDB Loader\n",
+    "\n",
+    "Intialize an AlloyDB Loader to fetch collection uuid from the \"langchain_pg_collection\" table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "phMW5OS1IOA9"
+   },
+   "outputs": [],
+   "source": [
+    "from langchain_google_alloydb_pg import AlloyDBLoader\n",
+    "\n",
+    "collection_name = \"test_table\"\n",
+    "collection_loader = AlloyDBLoader.create_sync(\n",
+    "    engine=engine,\n",
+    "    query=f\"SELECT * from langchain_pg_collection WHERE name='{collection_name}'\",\n",
+    ")\n",
+    "doc = collection_loader.load()\n",
+    "uuid = doc[0].page_content"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "5OAU-iFBcISC"
+   },
+   "source": [
+    "### Initialize an AlloyDBVectorStore on the embeddings data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "fE3U6VKRIdst"
+   },
+   "outputs": [],
+   "source": [
+    "embedding_vectorstore = AlloyDBVectorStore.create_sync(\n",
+    "    engine=engine,\n",
+    "    table_name=\"langchain_pg_embedding\",\n",
+    "    embedding_service=embeddings_service,\n",
+    "    content_column=\"document\",\n",
+    "    metadata_columns=[\"cmetadata\", \"collection_id\"],\n",
+    "    id_column=\"id\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "L9uA3d_tckNT"
+   },
+   "source": [
+    "### Perform basic similarity search"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "769GpGCnUdDZ",
+    "outputId": "7c73a7dc-51d7-410f-9862-dae99bb11413"
+   },
+   "outputs": [],
+   "source": [
+    "# Equivalent PGVector code:\n",
+    "# pg_vectorstore.similarity_search(\n",
+    "#     \"cats\", k=5\n",
+    "# )\n",
+    "\n",
+    "embedding_vectorstore.similarity_search(\"cats\", k=5, filter=f\"collection_id='{uuid}'\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Ux6KNk3Tcn2x"
+   },
+   "source": [
+    "### Perform similarity search with metadata filters\n",
+    "\n",
+    "The filter should be written using SQL syntax as it forms part of the WHERE clause in your query."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "eVwZdZ35VzZJ",
+    "outputId": "20ef5f10-147e-48f5-efe9-685bb74f0af5"
+   },
+   "outputs": [],
+   "source": [
+    "embedding_vectorstore.similarity_search(\n",
+    "    \"cats\", k=5, filter=f\"collection_id='{uuid}' and cmetadata->>'topic' = 'animals'\"\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/samples/pg_to_alloy_migration_search.ipynb
+++ b/samples/pg_to_alloy_migration_search.ipynb
@@ -1,0 +1,479 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# PGVector to AlloyDB Migration\n",
+        "Self Link: [go/pg-to-alloy-migration-search](http://go/pg-to-alloy-migration-search)"
+      ],
+      "metadata": {
+        "id": "QfhjUMPlX-2t"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Introduction\n",
+        "\n",
+        "In this codelab, you'll learn how to use AlloyDB interface for vector search in any DB created using the PGVector interface.\n",
+        "\n",
+        "This would allow you to migrate from using [PGVector](https://api.python.langchain.com/en/latest/vectorstores/langchain_postgres.vectorstores.PGVector.html#langchain_postgres.vectorstores.PGVector) to [AlloyDB Vector Store](https://github.com/googleapis/langchain-google-alloydb-pg-python/blob/main/docs/vector_store.ipynb) search methods.\n",
+        "\n",
+        "The AlloyDB interface simplifies secure connections to the AlloyDB database, even for users with little experience.\n"
+      ],
+      "metadata": {
+        "id": "C5buBYm2WTKV"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Before you begin\n",
+        "\n",
+        "This notebook assumes that you have done the following:\n",
+        "\n",
+        "* [Create a Google Cloud Project](https://developers.google.com/workspace/guides/create-project)\n",
+        "* [Enable the AlloyDB API](https://console.cloud.google.com/flows/enableapi?apiid=alloydb.googleapis.com)\n",
+        "* [Create a AlloyDB cluster and instance](https://cloud.google.com/alloydb/docs/cluster-create)\n",
+        "* [Create a AlloyDB database](https://cloud.google.com/alloydb/docs/quickstart/create-and-connect)\n",
+        "* [Add a User to the database](https://cloud.google.com/alloydb/docs/database-users/about)\n"
+      ],
+      "metadata": {
+        "id": "TE2CIamaXpqY"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "  ### 🦜🔗 Library Installation\n",
+        "  Install the integration library, `langchain-google-alloydb-pg`, and the library for the embedding service, `langchain-google-vertexai`."
+      ],
+      "metadata": {
+        "id": "yeFGQ9kPYs0W"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "%pip install --upgrade --quiet  langchain-google-alloydb-pg langchain-google-vertexai"
+      ],
+      "metadata": {
+        "id": "t-FWrCqVH7v5",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "e9e30198-d2ca-4365-b21b-d6ab0eeb0623"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "\u001b[?25l   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/2.7 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r\u001b[2K   \u001b[91m━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.8/2.7 MB\u001b[0m \u001b[31m26.0 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r\u001b[2K   \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m2.7/2.7 MB\u001b[0m \u001b[31m50.8 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m2.7/2.7 MB\u001b[0m \u001b[31m35.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25h"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "**Colab only:** Uncomment the following cell to restart the kernel or use the button to restart the kernel. For Vertex AI Workbench you can restart the terminal using the button on top."
+      ],
+      "metadata": {
+        "id": "Mj6qCBI7Y7sh"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# # Automatically restart kernel after installs so that your environment can access the new packages\n",
+        "# import IPython\n",
+        "\n",
+        "# app = IPython.Application.instance()\n",
+        "# app.kernel.do_shutdown(True)"
+      ],
+      "metadata": {
+        "id": "ziswhCwcY_MV"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### 🔐 Authentication\n",
+        "Authenticate to Google Cloud as the IAM user logged into this notebook in order to access your Google Cloud Project.\n",
+        "\n",
+        "* If you are using Colab to run this notebook, use the cell below and continue.\n",
+        "\n",
+        "* If you are using Vertex AI Workbench, check out the setup instructions [here](https://github.com/GoogleCloudPlatform/generative-ai/tree/main/setup-env)"
+      ],
+      "metadata": {
+        "id": "tib6qz9QH-Lh"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "MLA9smX8OBcM"
+      },
+      "outputs": [],
+      "source": [
+        "from google.colab import auth\n",
+        "\n",
+        "auth.authenticate_user()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "  ### ☁ Set Your Google Cloud Project\n",
+        "  Set your Google Cloud project so that you can leverage Google Cloud resources within this notebook.\n",
+        "  \n",
+        "  If you don't know your project ID, try the following:\n",
+        "\n",
+        "  * Run `gcloud config list`.\n",
+        "  * Run `gcloud projects list`.\n",
+        "  * See the support page: [Locate the project ID](https://support.google.com/googleapi/answer/7014113)."
+      ],
+      "metadata": {
+        "id": "92AhND6pIAPY"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# @markdown Please fill in the value below with your Google Cloud project ID and then run the cell.\n",
+        "\n",
+        "PROJECT_ID = \"twisha-dev\"  # @param {type:\"string\"}\n",
+        "\n",
+        "# Set the project id\n",
+        "!gcloud config set project {PROJECT_ID}"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "TqWdttLHOEsr",
+        "outputId": "29fa03ed-de0b-4ac1-95e7-6d33e566e66a"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Updated property [core/project].\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Basic Usage"
+      ],
+      "metadata": {
+        "id": "NqeEeQc6Z137"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Set AlloyDB database values\n",
+        "\n",
+        "Find your database values, in the [AlloyDB Instances page](https://console.cloud.google.com/alloydb/clusters)."
+      ],
+      "metadata": {
+        "id": "pAfvCrs1Z2Le"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# @title Set Your Values Here { display-mode: \"form\" }\n",
+        "REGION = \"us-central1\"  # @param {type: \"string\"}\n",
+        "CLUSTER = \"twisha-dev-cluster\"  # @param {type: \"string\"}\n",
+        "INSTANCE = \"my-primary\"  # @param {type: \"string\"}\n",
+        "DATABASE = \"test_db\"  # @param {type: \"string\"}"
+      ],
+      "metadata": {
+        "id": "A3BYZXQrOsQP"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### AlloyDBEngine Connection Pool\n",
+        "\n",
+        "One of the requirements and arguments to establish AlloyDB as a vector store is a `AlloyDBEngine` object. The `AlloyDBEngine`  configures a connection pool to your AlloyDB database, enabling successful connections from your application and following industry best practices.\n",
+        "\n",
+        "To create a `AlloyDBEngine` using `AlloyDBEngine.from_instance()` you need to provide only 5 things:\n",
+        "\n",
+        "1. `project_id` : Project ID of the Google Cloud Project where the AlloyDB instance is located.\n",
+        "2. `region` : Region where the AlloyDB instance is located.\n",
+        "3. `cluster`: The name of the AlloyDB cluster.\n",
+        "4. `instance` : The name of the AlloyDB instance.\n",
+        "5. `database` : The name of the database to connect to on the AlloyDB instance.\n",
+        "\n",
+        "\n",
+        "By default, [IAM database authentication](https://cloud.google.com/alloydb/docs/connect-iam) will be used as the method of database authentication. This library uses the IAM principal belonging to the [Application Default Credentials (ADC)](https://cloud.google.com/docs/authentication/application-default-credentials) sourced from the environment.\n",
+        "\n",
+        "Optionally, [built-in database authentication](https://cloud.google.com/alloydb/docs/database-users/about) using a username and password to access the AlloyDB database can also be used. Just provide the optional `user` and `password` arguments to `AlloyDBEngine.from_instance()`:\n",
+        "\n",
+        "* `user` : Database user to use for built-in database authentication and login.\n",
+        "* `password` : Database password to use for built-in database authentication and login."
+      ],
+      "metadata": {
+        "id": "dS3X75KpabxA"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# @title Set Your Values Here { display-mode: \"form\" }\n",
+        "USER = \"postgres\"  # @param {type: \"string\"}\n",
+        "PASSWORD = \"alloydb\"  # @param {type: \"string\"}"
+      ],
+      "metadata": {
+        "id": "HPcWWr_LaLqD"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Create a connection to your AlloyDB for PostgreSQL instance using the AlloyDBEngine class.\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "5_-kcRf4bJ8B"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from langchain_google_alloydb_pg import AlloyDBEngine, AlloyDBVectorStore, Column\n",
+        "from langchain_core.documents import Document\n",
+        "import uuid\n",
+        "\n",
+        "engine = AlloyDBEngine.from_instance(\n",
+        "    project_id=PROJECT_ID,\n",
+        "    region=REGION,\n",
+        "    cluster=CLUSTER,\n",
+        "    instance=INSTANCE,\n",
+        "    database=DATABASE,\n",
+        "    user=USER,\n",
+        "    password=PASSWORD,\n",
+        ")"
+      ],
+      "metadata": {
+        "id": "rWlcGt3JIDIy"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Create an embedding class instance\n",
+        "\n",
+        "You can use any [LangChain embeddings model](https://python.langchain.com/docs/integrations/text_embedding/).\n",
+        "You may need to enable Vertex AI API to use `VertexAIEmbeddings`. We recommend setting the embedding model's version for production, learn more about the [Text embeddings models](https://cloud.google.com/vertex-ai/docs/generative-ai/model-reference/text-embeddings)."
+      ],
+      "metadata": {
+        "id": "qI3IdMdubu4y"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# enable Vertex AI API\n",
+        "!gcloud services enable aiplatform.googleapis.com"
+      ],
+      "metadata": {
+        "id": "vMeZsVuLb_6g"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from langchain_google_vertexai import VertexAIEmbeddings\n",
+        "\n",
+        "embeddings_service = VertexAIEmbeddings(\n",
+        "    model_name=\"textembedding-gecko@003\", project=PROJECT_ID\n",
+        ")"
+      ],
+      "metadata": {
+        "id": "69OOOCWebc5X"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Initialize an AlloyDB Loader\n",
+        "\n",
+        "Intialize an AlloyDB Loader to fetch collection uuid from the \"langchain_pg_collection\" table"
+      ],
+      "metadata": {
+        "id": "iY8oA59vcL7_"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from langchain_google_alloydb_pg import AlloyDBLoader\n",
+        "\n",
+        "collection_name = \"test_table\"\n",
+        "collection_loader = AlloyDBLoader.create_sync(\n",
+        "    engine=engine,\n",
+        "    query=f\"SELECT * from langchain_pg_collection WHERE name='{collection_name}'\"\n",
+        ")\n",
+        "doc = collection_loader.load()\n",
+        "uuid = doc[0].page_content"
+      ],
+      "metadata": {
+        "id": "phMW5OS1IOA9"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Initialize an AlloyDBVectorStore on the embeddings data"
+      ],
+      "metadata": {
+        "id": "5OAU-iFBcISC"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "embedding_vectorstore = AlloyDBVectorStore.create_sync(\n",
+        "    engine=engine,\n",
+        "    table_name=\"langchain_pg_embedding\",\n",
+        "    embedding_service=embeddings_service,\n",
+        "    content_column=\"document\",\n",
+        "    metadata_columns=[\"cmetadata\", \"collection_id\"],\n",
+        "    id_column=\"id\",\n",
+        ")"
+      ],
+      "metadata": {
+        "id": "fE3U6VKRIdst"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Perform basic similarity search"
+      ],
+      "metadata": {
+        "id": "L9uA3d_tckNT"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Equivalent PGVector code:\n",
+        "# pg_vectorstore.similarity_search(\n",
+        "#     \"cats\", k=5\n",
+        "# )\n",
+        "\n",
+        "embedding_vectorstore.similarity_search(\n",
+        "    \"cats\", k=5, filter=f\"collection_id='{uuid}'\"\n",
+        ")"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "769GpGCnUdDZ",
+        "outputId": "7c73a7dc-51d7-410f-9862-dae99bb11413"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "[Document(metadata={'cmetadata': {'id': 1, 'topic': 'animals', 'location': 'pond'}, 'collection_id': UUID('90462d20-97e5-4094-ba4b-9e2b776938e6')}, page_content='there are cats in the pond'),\n",
+              " Document(metadata={'cmetadata': {'id': 5, 'topic': 'art', 'location': 'museum'}, 'collection_id': UUID('90462d20-97e5-4094-ba4b-9e2b776938e6')}, page_content='the new art exhibit is fascinating'),\n",
+              " Document(metadata={'cmetadata': {'id': 6, 'topic': 'art', 'location': 'museum'}, 'collection_id': UUID('90462d20-97e5-4094-ba4b-9e2b776938e6')}, page_content='a sculpture exhibit is also at the museum'),\n",
+              " Document(metadata={'cmetadata': {'id': 2, 'topic': 'animals', 'location': 'pond'}, 'collection_id': UUID('90462d20-97e5-4094-ba4b-9e2b776938e6')}, page_content='ducks are also found in the pond'),\n",
+              " Document(metadata={'cmetadata': {'id': 9, 'topic': 'reading', 'location': 'library'}, 'collection_id': UUID('90462d20-97e5-4094-ba4b-9e2b776938e6')}, page_content='the library hosts a weekly story time for kids')]"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 27
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Perform similarity search with metadata filters\n",
+        "\n",
+        "The filter should be written using SQL syntax as it forms part of the WHERE clause in your query."
+      ],
+      "metadata": {
+        "id": "Ux6KNk3Tcn2x"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "embedding_vectorstore.similarity_search(\n",
+        "    \"cats\", k=5, filter=f\"collection_id='{uuid}' and cmetadata->>'topic' = 'animals'\"\n",
+        ")"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "eVwZdZ35VzZJ",
+        "outputId": "20ef5f10-147e-48f5-efe9-685bb74f0af5"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "[Document(metadata={'cmetadata': {'id': 1, 'topic': 'animals', 'location': 'pond'}, 'collection_id': UUID('90462d20-97e5-4094-ba4b-9e2b776938e6')}, page_content='there are cats in the pond'),\n",
+              " Document(metadata={'cmetadata': {'id': 2, 'topic': 'animals', 'location': 'pond'}, 'collection_id': UUID('90462d20-97e5-4094-ba4b-9e2b776938e6')}, page_content='ducks are also found in the pond')]"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 29
+        }
+      ]
+    }
+  ]
+}

--- a/samples/pg_to_alloy_migration_search.ipynb
+++ b/samples/pg_to_alloy_migration_search.ipynb
@@ -307,13 +307,49 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Corresponding PGVector code"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# from google.cloud.alloydb.connector import Connector, IPTypes\n",
+    "# import sqlalchemy\n",
+    "\n",
+    "# connection_string = f\"projects/{PROJECT_ID}/locations/{REGION}/clusters/{CLUSTER}/instances/{INSTANCE}\"\n",
+    "# # initialize Connector object\n",
+    "# connector = Connector()\n",
+    "\n",
+    "# # function to return the database connection\n",
+    "# def getconn():\n",
+    "#     conn = connector.connect(\n",
+    "#         connection_string,\n",
+    "#         \"pg8000\",\n",
+    "#         user=USER,\n",
+    "#         password=PASSWORD,\n",
+    "#         db=DATABASE,\n",
+    "#         enable_iam_auth=False,\n",
+    "#         ip_type=IPTypes.PUBLIC,\n",
+    "#     )\n",
+    "#     return conn\n",
+    "\n",
+    "\n",
+    "# # create connection pool\n",
+    "# pool = sqlalchemy.create_engine(\"postgresql+pg8000://\", creator=getconn)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "iY8oA59vcL7_"
    },
    "source": [
-    "### Initialize an AlloyDB Loader\n",
-    "\n",
-    "Intialize an AlloyDB Loader to fetch the uuid corresponding to the collection.\n",
+    "### Initialize an AlloyDB Loader to fetch the collection uuid\n",
     "\n",
     "PGvector sets up two tables. \n",
     "\n",
@@ -331,7 +367,15 @@
    "source": [
     "from langchain_google_alloydb_pg import AlloyDBLoader\n",
     "\n",
-    "# Choose the collection to perform vector search on\n",
+    "# Choose the collection to perform vector search on.\n",
+    "# This is set in the PGVector while creating the vectorstore using the code snippet below\n",
+    "# pg_vectorstore = PGVector(\n",
+    "#     embeddings=embedding_service,\n",
+    "#     collection_name=\"test_table\",\n",
+    "#     connection=pool,\n",
+    "#     use_jsonb=True,\n",
+    "#     create_extension=False\n",
+    "# )\n",
     "collection_name = \"test_table\"\n",
     "\n",
     "# The langchain_pg_collection table usually stores collection-to-UUID mappings.\n",

--- a/samples/pg_to_alloy_migration_search.ipynb
+++ b/samples/pg_to_alloy_migration_search.ipynb
@@ -78,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -86,15 +86,7 @@
     "id": "t-FWrCqVH7v5",
     "outputId": "e9e30198-d2ca-4365-b21b-d6ab0eeb0623"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%pip install --upgrade --quiet  langchain-google-alloydb-pg langchain-google-vertexai"
    ]
@@ -110,7 +102,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "id": "ziswhCwcY_MV"
    },
@@ -139,23 +131,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "id": "MLA9smX8OBcM"
    },
-   "outputs": [
-    {
-     "ename": "ModuleNotFoundError",
-     "evalue": "No module named 'google.colab'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[9], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mgoogle\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mcolab\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m auth\n\u001b[1;32m      3\u001b[0m auth\u001b[38;5;241m.\u001b[39mauthenticate_user()\n",
-      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'google.colab'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from google.colab import auth\n",
     "\n",

--- a/samples/pg_to_alloy_migration_search.ipynb
+++ b/samples/pg_to_alloy_migration_search.ipynb
@@ -42,7 +42,7 @@
     "\n",
     "## Introduction\n",
     "\n",
-    "In this codelab, you'll learn how to use AlloyDB interface for vector search in any DB created using the PGVector interface.\n",
+    "In this notebook, you'll learn how to use the AlloyDBVectorStore interface for vector search from vector stores created when using the PGVector interface.\n",
     "\n",
     "This would allow you to migrate from using [PGVector](https://api.python.langchain.com/en/latest/vectorstores/langchain_postgres.vectorstores.PGVector.html#langchain_postgres.vectorstores.PGVector) to [AlloyDB Vector Store](https://github.com/googleapis/langchain-google-alloydb-pg-python/blob/main/docs/vector_store.ipynb) search methods.\n",
     "\n",


### PR DESCRIPTION
This code samples shows users how to use AlloyDB interface for vector search in any DB created using the PGVector interface.

This would allow you to migrate from using [PGVector](https://api.python.langchain.com/en/latest/vectorstores/langchain_postgres.vectorstores.PGVector.html#langchain_postgres.vectorstores.PGVector) to [AlloyDB Vector Store](https://github.com/googleapis/langchain-google-alloydb-pg-python/blob/main/docs/vector_store.ipynb) search methods.