### PR TITLE
feat: Add multi-modal support vector store

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,8 @@ test = [
     "mypy==1.11.2",
     "pytest-asyncio==0.24.0",
     "pytest==8.3.3",
-    "pytest-cov==5.0.0"
+    "pytest-cov==5.0.0",
+    "Pillow==10.4.0"
 ]
 
 [build-system]

--- a/src/langchain_google_alloydb_pg/async_vectorstore.py
+++ b/src/langchain_google_alloydb_pg/async_vectorstore.py
@@ -319,7 +319,16 @@ class AsyncAlloyDBVectorStore(VectorStore):
         ids: Optional[List[str]] = None,
         **kwargs: Any,
     ) -> List[str]:
-        """Embed images and add to the table."""
+        """Embed images and add to the table.
+
+        Args:
+            uris (List[str]): List of local image URIs to add to the table.
+            metadatas (Optional[List[dict]]): List of metadatas to add to table records.
+            ids: (Optional[List[str]]): List of IDs to add to table records.
+
+        Returns:
+            List of record IDs added.
+        """
         encoded_images = []
         if metadatas is None:
             metadatas = [{"image_uri": uri} for uri in uris]

--- a/src/langchain_google_alloydb_pg/async_vectorstore.py
+++ b/src/langchain_google_alloydb_pg/async_vectorstore.py
@@ -329,7 +329,7 @@ class AsyncAlloyDBVectorStore(VectorStore):
             encoded_images.append(encoded_image)
 
         embeddings = self._images_embedding_helper(uris)
-        ids = await self.__aadd_embeddings(
+        ids = await self.aadd_embeddings(
             encoded_images, embeddings, metadatas=metadatas, ids=ids, **kwargs
         )
         return ids

--- a/src/langchain_google_alloydb_pg/async_vectorstore.py
+++ b/src/langchain_google_alloydb_pg/async_vectorstore.py
@@ -329,7 +329,7 @@ class AsyncAlloyDBVectorStore(VectorStore):
             encoded_images.append(encoded_image)
 
         embeddings = self._images_embedding_helper(uris)
-        ids = await self._aadd_embeddings(
+        ids = await self.__aadd_embeddings(
             encoded_images, embeddings, metadatas=metadatas, ids=ids, **kwargs
         )
         return ids
@@ -563,8 +563,8 @@ class AsyncAlloyDBVectorStore(VectorStore):
         """Return docs selected by similarity search on query."""
         embedding = self._images_embedding_helper([image_uri])[0]
 
-        return self._engine._run_as_sync(
-            self.__vs.asimilarity_search_by_vector(embedding, k, filter, **kwargs)
+        return await self.asimilarity_search_by_vector(
+            embedding=embedding, k=k, filter=filter, **kwargs
         )
 
     def _select_relevance_score_fn(self) -> Callable[[float], float]:

--- a/src/langchain_google_alloydb_pg/vectorstore.py
+++ b/src/langchain_google_alloydb_pg/vectorstore.py
@@ -290,7 +290,7 @@ class AlloyDBVectorStore(VectorStore):
         **kwargs: Any,
     ) -> List[str]:
         """Embed images and add to the table."""
-        return self.engine._run_as_sync(
+        return self._engine._run_as_sync(
             self.__vs.aadd_images(uris, metadatas, ids, **kwargs)
         )
 

--- a/src/langchain_google_alloydb_pg/vectorstore.py
+++ b/src/langchain_google_alloydb_pg/vectorstore.py
@@ -226,6 +226,18 @@ class AlloyDBVectorStore(VectorStore):
             self.__vs.aadd_documents(documents, ids, **kwargs)
         )
 
+    async def aadd_images(
+        self,
+        uris: List[str],
+        metadatas: Optional[List[dict]] = None,
+        ids: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> List[str]:
+        """Embed images and add to the table."""
+        return await self._engine._run_as_async(
+            self.__vs.aadd_images(uris, metadatas, ids, **kwargs)
+        )
+
     def add_embeddings(
         self,
         texts: Iterable[str],
@@ -268,6 +280,18 @@ class AlloyDBVectorStore(VectorStore):
         """
         return self._engine._run_as_sync(
             self.__vs.aadd_documents(documents, ids, **kwargs)
+        )
+
+    def add_images(
+        self,
+        uris: List[str],
+        metadatas: Optional[List[dict]] = None,
+        ids: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> List[str]:
+        """Embed images and add to the table."""
+        return self.engine._run_as_sync(
+            self.__vs.aadd_images(uris, metadatas, ids, **kwargs)
         )
 
     async def adelete(
@@ -589,6 +613,18 @@ class AlloyDBVectorStore(VectorStore):
             self.__vs.asimilarity_search(query, k, filter, **kwargs)
         )
 
+    def similarity_search_image(
+        self,
+        image_uri: str,
+        k: Optional[int] = None,
+        filter: Optional[str] = None,
+        **kwargs: Any,
+    ) -> List[Document]:
+        """Return docs selected by similarity search on image."""
+        return self._engine._run_as_sync(
+            self.__vs.asimilarity_search_image(image_uri, k, filter, **kwargs)
+        )
+
     async def asimilarity_search(
         self,
         query: str,
@@ -599,6 +635,18 @@ class AlloyDBVectorStore(VectorStore):
         """Return docs selected by similarity search on query."""
         return await self._engine._run_as_async(
             self.__vs.asimilarity_search(query, k, filter, **kwargs)
+        )
+
+    async def asimilarity_search_image(
+        self,
+        image_uri: str,
+        k: Optional[int] = None,
+        filter: Optional[str] = None,
+        **kwargs: Any,
+    ) -> List[Document]:
+        """Return docs selected by similarity search on query."""
+        return await self._engine._run_as_async(
+            self.__vs.asimilarity_search(image_uri, k, filter, **kwargs)
         )
 
     # Required for (a)similarity_search_with_relevance_scores

--- a/tests/test_async_vectorstore.py
+++ b/tests/test_async_vectorstore.py
@@ -149,13 +149,14 @@ class TestVectorStore:
         await engine._ainit_vectorstore_table(
             IMAGE_TABLE,
             VECTOR_SIZE,
-            metadata_columns=[Column("image_id", "INTEGER"), Column("source", "TEXT")],
-            metadata_json_column="mymeta",
+            metadata_columns=[Column("image_id", "TEXT"), Column("source", "TEXT")],
         )
         vs = await AsyncAlloyDBVectorStore.create(
             engine,
             embedding_service=image_embedding_service,
             table_name=IMAGE_TABLE,
+            metadata_columns=["image_id", "source"],
+            metadata_json_column="mymeta",
         )
         yield vs
 
@@ -242,7 +243,7 @@ class TestVectorStore:
         await image_vs.aadd_images(image_uris, metadatas, ids)
         results = await afetch(engine, (f'SELECT * FROM "{IMAGE_TABLE}"'))
         assert len(results) == 3
-        assert results[0]["image_id"] == 0
+        assert results[0]["image_id"] == ids[0]
         assert results[0]["source"] == "google.com"
         await aexecute(engine, (f'TRUNCATE TABLE "{IMAGE_TABLE}"'))
 

--- a/tests/test_async_vectorstore.py
+++ b/tests/test_async_vectorstore.py
@@ -161,9 +161,9 @@ class TestVectorStore:
 
     @pytest_asyncio.fixture(scope="class")
     async def image_uris(self):
-        red_uri = "test_image_red.jpg" + str(uuid.uuid4()).replace("-", "_")
-        green_uri = "test_image_green.jpg" + str(uuid.uuid4()).replace("-", "_")
-        blue_uri = "test_image_blue.jpg" + str(uuid.uuid4()).replace("-", "_")
+        red_uri = str(uuid.uuid4()).replace("-", "_") + "test_image_red.jpg"
+        green_uri = str(uuid.uuid4()).replace("-", "_") + "test_image_green.jpg"
+        blue_uri = str(uuid.uuid4()).replace("-", "_") + "test_image_blue.jpg"
         image = Image.new("RGB", (100, 100), color="red")
         image.save(red_uri)
         image = Image.new("RGB", (100, 100), color="green")

--- a/tests/test_async_vectorstore.py
+++ b/tests/test_async_vectorstore.py
@@ -243,7 +243,7 @@ class TestVectorStore:
         await image_vs.aadd_images(image_uris, metadatas, ids)
         results = await afetch(engine, (f'SELECT * FROM "{IMAGE_TABLE}"'))
         assert len(results) == 3
-        assert results[0]["image_id"] == ids[0]
+        assert results[0]["image_id"] == "0"
         assert results[0]["source"] == "google.com"
         await aexecute(engine, (f'TRUNCATE TABLE "{IMAGE_TABLE}"'))
 

--- a/tests/test_async_vectorstore.py
+++ b/tests/test_async_vectorstore.py
@@ -146,7 +146,7 @@ class TestVectorStore:
 
     @pytest_asyncio.fixture(scope="class")
     async def image_vs(self, engine):
-        await engine.ainit_vectorstore_table(
+        await engine._ainit_vectorstore_table(
             IMAGE_TABLE,
             VECTOR_SIZE,
             metadata_columns=[Column("image_id", "INTEGER"), Column("source", "TEXT")],

--- a/tests/test_async_vectorstore.py
+++ b/tests/test_async_vectorstore.py
@@ -161,17 +161,16 @@ class TestVectorStore:
 
     @pytest_asyncio.fixture(scope="class")
     async def image_uris(self):
+        red_uri = "test_image_red.jpg" + str(uuid.uuid4()).replace("-", "_")
+        green_uri = "test_image_green.jpg" + str(uuid.uuid4()).replace("-", "_")
+        blue_uri = "test_image_blue.jpg" + str(uuid.uuid4()).replace("-", "_")
         image = Image.new("RGB", (100, 100), color="red")
-        image.save("test_image_red.jpg")
+        image.save(red_uri)
         image = Image.new("RGB", (100, 100), color="green")
-        image.save("test_image_green.jpg")
+        image.save(green_uri)
         image = Image.new("RGB", (100, 100), color="blue")
-        image.save("test_image_blue.jpg")
-        image_uris = [
-            "test_image_red.jpg",
-            "test_image_green.jpg",
-            "test_image_blue.jpg",
-        ]
+        image.save(blue_uri)
+        image_uris = [red_uri, green_uri, blue_uri]
         yield image_uris
         for uri in image_uris:
             os.remove(uri)

--- a/tests/test_async_vectorstore.py
+++ b/tests/test_async_vectorstore.py
@@ -241,11 +241,11 @@ class TestVectorStore:
             {"image_id": str(i), "source": "google.com"} for i in range(len(image_uris))
         ]
         await image_vs.aadd_images(image_uris, metadatas, ids)
-        results = await engine._afetch(f'SELECT * FROM "{IMAGE_TABLE}"')
+        results = await afetch(engine, (f'SELECT * FROM "{IMAGE_TABLE}"'))
         assert len(results) == 3
         assert results[0]["image_id"] == 0
         assert results[0]["source"] == "google.com"
-        await engine._aexecute(f'TRUNCATE TABLE "{IMAGE_TABLE}"')
+        await aexecute(engine, (f'TRUNCATE TABLE "{IMAGE_TABLE}"'))
 
     async def test_adelete(self, engine, vs):
         ids = [str(uuid.uuid4()) for i in range(len(texts))]

--- a/tests/test_async_vectorstore.py
+++ b/tests/test_async_vectorstore.py
@@ -14,12 +14,13 @@
 
 import os
 import uuid
-from typing import Sequence
+from typing import List, Sequence
 
 import pytest
 import pytest_asyncio
 from langchain_core.documents import Document
 from langchain_core.embeddings import DeterministicFakeEmbedding
+from PIL import Image
 from sqlalchemy import text
 from sqlalchemy.engine.row import RowMapping
 
@@ -29,6 +30,7 @@ from langchain_google_alloydb_pg.async_vectorstore import AsyncAlloyDBVectorStor
 DEFAULT_TABLE = "test_table" + str(uuid.uuid4())
 DEFAULT_TABLE_SYNC = "test_table_sync" + str(uuid.uuid4())
 CUSTOM_TABLE = "test-table-custom" + str(uuid.uuid4())
+IMAGE_TABLE = "test_image_table" + str(uuid.uuid4())
 VECTOR_SIZE = 768
 
 embeddings_service = DeterministicFakeEmbedding(size=VECTOR_SIZE)
@@ -40,6 +42,15 @@ docs = [
 ]
 
 embeddings = [embeddings_service.embed_query(texts[i]) for i in range(len(texts))]
+
+
+class FakeImageEmbedding(DeterministicFakeEmbedding):
+
+    def embed_image(self, image_paths: List[str]) -> List[List[float]]:
+        return [self.embed_query(path) for path in image_paths]
+
+
+image_embedding_service = FakeImageEmbedding(size=VECTOR_SIZE)
 
 
 def get_env_var(key: str, desc: str) -> str:
@@ -133,6 +144,38 @@ class TestVectorStore:
         )
         yield vs
 
+    @pytest_asyncio.fixture(scope="class")
+    async def image_vs(self, engine):
+        await engine.ainit_vectorstore_table(
+            IMAGE_TABLE,
+            VECTOR_SIZE,
+            metadata_columns=[Column("image_id", "INTEGER"), Column("source", "TEXT")],
+            metadata_json_column="mymeta",
+        )
+        vs = await AsyncAlloyDBVectorStore.create(
+            engine,
+            embedding_service=image_embedding_service,
+            table_name=IMAGE_TABLE,
+        )
+        yield vs
+
+    @pytest_asyncio.fixture(scope="class")
+    async def image_uris(self):
+        image = Image.new("RGB", (100, 100), color="red")
+        image.save("test_image_red.jpg")
+        image = Image.new("RGB", (100, 100), color="green")
+        image.save("test_image_green.jpg")
+        image = Image.new("RGB", (100, 100), color="blue")
+        image.save("test_image_blue.jpg")
+        image_uris = [
+            "test_image_red.jpg",
+            "test_image_green.jpg",
+            "test_image_blue.jpg",
+        ]
+        yield image_uris
+        for uri in image_uris:
+            os.remove(uri)
+
     async def test_init_with_constructor(self, engine):
         with pytest.raises(Exception):
             AsyncAlloyDBVectorStore(
@@ -191,6 +234,18 @@ class TestVectorStore:
         results = await afetch(engine, f'SELECT * FROM "{DEFAULT_TABLE}"')
         assert len(results) == 3
         await aexecute(engine, f'TRUNCATE TABLE "{DEFAULT_TABLE}"')
+
+    async def test_aadd_images(self, engine, image_vs, image_uris):
+        ids = [str(uuid.uuid4()) for i in range(len(image_uris))]
+        metadatas = [
+            {"image_id": str(i), "source": "google.com"} for i in range(len(image_uris))
+        ]
+        await image_vs.aadd_images(image_uris, metadatas, ids)
+        results = await engine._afetch(f'SELECT * FROM "{IMAGE_TABLE}"')
+        assert len(results) == 3
+        assert results[0]["image_id"] == 0
+        assert results[0]["source"] == "google.com"
+        await engine._aexecute(f'TRUNCATE TABLE "{IMAGE_TABLE}"')
 
     async def test_adelete(self, engine, vs):
         ids = [str(uuid.uuid4()) for i in range(len(texts))]

--- a/tests/test_async_vectorstore_search.py
+++ b/tests/test_async_vectorstore_search.py
@@ -282,9 +282,8 @@ class TestVectorStoreSearch:
         assert results == [Document(page_content="bar")]
 
     async def test_similarity_search_image(self, image_vs, image_uris):
-        results = await image_vs.similarity_search_image(image_uris[0], k=1)
-        assert len(results) == 1
-        assert results[0].metadata["image_uri"] == image_uris[0]
+        with pytest.raises(NotImplementedError):
+            await image_vs.similarity_search_image(image_uris[0], k=1)
 
     async def test_similarity_search_score(self, vs_custom):
         results = await vs_custom.asimilarity_search_with_score("foo")

--- a/tests/test_async_vectorstore_search.py
+++ b/tests/test_async_vectorstore_search.py
@@ -165,7 +165,7 @@ class TestVectorStoreSearch:
 
     @pytest_asyncio.fixture(scope="class")
     async def image_vs(self, engine, image_uris):
-        await engine.ainit_vectorstore_table(IMAGE_TABLE, VECTOR_SIZE)
+        await engine._ainit_vectorstore_table(IMAGE_TABLE, VECTOR_SIZE)
         vs = await AsyncAlloyDBVectorStore.create(
             engine,
             embedding_service=image_embedding_service,

--- a/tests/test_async_vectorstore_search.py
+++ b/tests/test_async_vectorstore_search.py
@@ -29,7 +29,7 @@ from langchain_google_alloydb_pg.indexes import DistanceStrategy, HNSWQueryOptio
 
 DEFAULT_TABLE = "test_table" + str(uuid.uuid4()).replace("-", "_")
 CUSTOM_TABLE = "test_table_custom" + str(uuid.uuid4()).replace("-", "_")
-IMAGE_TABLE = "test_iamge_table" + str(uuid.uuid4()).replace("-", "_")
+IMAGE_TABLE = "test_image_table" + str(uuid.uuid4()).replace("-", "_")
 VECTOR_SIZE = 768
 
 embeddings_service = DeterministicFakeEmbedding(size=VECTOR_SIZE)
@@ -148,17 +148,16 @@ class TestVectorStoreSearch:
 
     @pytest_asyncio.fixture(scope="class")
     async def image_uris(self):
+        red_uri = "test_image_red.jpg" + str(uuid.uuid4()).replace("-", "_")
+        green_uri = "test_image_green.jpg" + str(uuid.uuid4()).replace("-", "_")
+        blue_uri = "test_image_blue.jpg" + str(uuid.uuid4()).replace("-", "_")
         image = Image.new("RGB", (100, 100), color="red")
-        image.save("test_image_red_search.jpg")
+        image.save(red_uri)
         image = Image.new("RGB", (100, 100), color="green")
-        image.save("test_image_green_search.jpg")
+        image.save(green_uri)
         image = Image.new("RGB", (100, 100), color="blue")
-        image.save("test_image_blue_search.jpg")
-        image_uris = [
-            "test_image_red_search.jpg",
-            "test_image_green_search.jpg",
-            "test_image_blue_search.jpg",
-        ]
+        image.save(blue_uri)
+        image_uris = [red_uri, green_uri, blue_uri]
         yield image_uris
         for uri in image_uris:
             os.remove(uri)

--- a/tests/test_async_vectorstore_search.py
+++ b/tests/test_async_vectorstore_search.py
@@ -148,9 +148,9 @@ class TestVectorStoreSearch:
 
     @pytest_asyncio.fixture(scope="class")
     async def image_uris(self):
-        red_uri = "test_image_red.jpg" + str(uuid.uuid4()).replace("-", "_")
-        green_uri = "test_image_green.jpg" + str(uuid.uuid4()).replace("-", "_")
-        blue_uri = "test_image_blue.jpg" + str(uuid.uuid4()).replace("-", "_")
+        red_uri = str(uuid.uuid4()).replace("-", "_") + "test_image_red.jpg"
+        green_uri = str(uuid.uuid4()).replace("-", "_") + "test_image_green.jpg"
+        blue_uri = str(uuid.uuid4()).replace("-", "_") + "test_image_blue.jpg"
         image = Image.new("RGB", (100, 100), color="red")
         image.save(red_uri)
         image = Image.new("RGB", (100, 100), color="green")

--- a/tests/test_async_vectorstore_search.py
+++ b/tests/test_async_vectorstore_search.py
@@ -14,11 +14,13 @@
 
 import os
 import uuid
+from typing import List
 
 import pytest
 import pytest_asyncio
 from langchain_core.documents import Document
 from langchain_core.embeddings import DeterministicFakeEmbedding
+from PIL import Image
 from sqlalchemy import text
 
 from langchain_google_alloydb_pg import AlloyDBEngine, Column
@@ -27,6 +29,7 @@ from langchain_google_alloydb_pg.indexes import DistanceStrategy, HNSWQueryOptio
 
 DEFAULT_TABLE = "test_table" + str(uuid.uuid4()).replace("-", "_")
 CUSTOM_TABLE = "test_table_custom" + str(uuid.uuid4()).replace("-", "_")
+IMAGE_TABLE = "test_iamge_table" + str(uuid.uuid4()).replace("-", "_")
 VECTOR_SIZE = 768
 
 embeddings_service = DeterministicFakeEmbedding(size=VECTOR_SIZE)
@@ -39,6 +42,15 @@ docs = [
 ]
 
 embeddings = [embeddings_service.embed_query("foo") for i in range(len(texts))]
+
+
+class FakeImageEmbedding(DeterministicFakeEmbedding):
+
+    def embed_image(self, image_paths: List[str]) -> List[List[float]]:
+        return [self.embed_query(path) for path in image_paths]
+
+
+image_embedding_service = FakeImageEmbedding(size=VECTOR_SIZE)
 
 
 def get_env_var(key: str, desc: str) -> str:
@@ -134,12 +146,47 @@ class TestVectorStoreSearch:
         await vs_custom.aadd_documents(docs, ids=ids)
         yield vs_custom
 
+    @pytest_asyncio.fixture(scope="class")
+    async def image_uris(self):
+        image = Image.new("RGB", (100, 100), color="red")
+        image.save("test_image_red_search.jpg")
+        image = Image.new("RGB", (100, 100), color="green")
+        image.save("test_image_green_search.jpg")
+        image = Image.new("RGB", (100, 100), color="blue")
+        image.save("test_image_blue_search.jpg")
+        image_uris = [
+            "test_image_red_search.jpg",
+            "test_image_green_search.jpg",
+            "test_image_blue_search.jpg",
+        ]
+        yield image_uris
+        for uri in image_uris:
+            os.remove(uri)
+
+    @pytest_asyncio.fixture(scope="class")
+    async def image_vs(self, engine, image_uris):
+        await engine.ainit_vectorstore_table(IMAGE_TABLE, VECTOR_SIZE)
+        vs = await AsyncAlloyDBVectorStore.create(
+            engine,
+            embedding_service=image_embedding_service,
+            table_name=IMAGE_TABLE,
+            distance_strategy=DistanceStrategy.COSINE_DISTANCE,
+        )
+        ids = [str(uuid.uuid4()) for i in range(len(image_uris))]
+        await vs.aadd_images(image_uris, ids=ids)
+        yield vs
+
     async def test_asimilarity_search(self, vs):
         results = await vs.asimilarity_search("foo", k=1)
         assert len(results) == 1
         assert results == [Document(page_content="foo")]
         results = await vs.asimilarity_search("foo", k=1, filter="content = 'bar'")
         assert results == [Document(page_content="bar")]
+
+    async def test_asimilarity_search_image(self, image_vs, image_uris):
+        results = await image_vs.asimilarity_search_image(image_uris[0], k=1)
+        assert len(results) == 1
+        assert results[0].metadata["image_uri"] == image_uris[0]
 
     async def test_asimilarity_search_score(self, vs):
         results = await vs.asimilarity_search_with_score("foo")
@@ -233,6 +280,11 @@ class TestVectorStoreSearch:
             "foo", k=1, filter="mycontent = 'bar'"
         )
         assert results == [Document(page_content="bar")]
+
+    async def test_similarity_search_image(self, image_vs, image_uris):
+        results = await image_vs.similarity_search_image(image_uris[0], k=1)
+        assert len(results) == 1
+        assert results[0].metadata["image_uri"] == image_uris[0]
 
     async def test_similarity_search_score(self, vs_custom):
         results = await vs_custom.asimilarity_search_with_score("foo")

--- a/tests/test_vectorstore.py
+++ b/tests/test_vectorstore.py
@@ -195,9 +195,9 @@ class TestVectorStore:
 
     @pytest_asyncio.fixture(scope="class")
     async def image_uris(self):
-        red_uri = "test_image_red.jpg" + str(uuid.uuid4()).replace("-", "_")
-        green_uri = "test_image_green.jpg" + str(uuid.uuid4()).replace("-", "_")
-        blue_uri = "test_image_blue.jpg" + str(uuid.uuid4()).replace("-", "_")
+        red_uri = str(uuid.uuid4()).replace("-", "_") + "test_image_red.jpg"
+        green_uri = str(uuid.uuid4()).replace("-", "_") + "test_image_green.jpg"
+        blue_uri = str(uuid.uuid4()).replace("-", "_") + "test_image_blue.jpg"
         image = Image.new("RGB", (100, 100), color="red")
         image.save(red_uri)
         image = Image.new("RGB", (100, 100), color="green")

--- a/tests/test_vectorstore.py
+++ b/tests/test_vectorstore.py
@@ -195,17 +195,16 @@ class TestVectorStore:
 
     @pytest_asyncio.fixture(scope="class")
     async def image_uris(self):
+        red_uri = "test_image_red.jpg" + str(uuid.uuid4()).replace("-", "_")
+        green_uri = "test_image_green.jpg" + str(uuid.uuid4()).replace("-", "_")
+        blue_uri = "test_image_blue.jpg" + str(uuid.uuid4()).replace("-", "_")
         image = Image.new("RGB", (100, 100), color="red")
-        image.save("test_image_red.jpg")
+        image.save(red_uri)
         image = Image.new("RGB", (100, 100), color="green")
-        image.save("test_image_green.jpg")
+        image.save(green_uri)
         image = Image.new("RGB", (100, 100), color="blue")
-        image.save("test_image_blue.jpg")
-        image_uris = [
-            "test_image_red.jpg",
-            "test_image_green.jpg",
-            "test_image_blue.jpg",
-        ]
+        image.save(blue_uri)
+        image_uris = [red_uri, green_uri, blue_uri]
         yield image_uris
         for uri in image_uris:
             os.remove(uri)

--- a/tests/test_vectorstore.py
+++ b/tests/test_vectorstore.py
@@ -201,8 +201,7 @@ class TestVectorStore:
             table_name=IMAGE_TABLE_SYNC,
         )
         yield vs
-        engine_sync._execute(f'DROP TABLE IF EXISTS "{IMAGE_TABLE_SYNC}"')
-        engine_sync._engine.dispose()
+        await aexecute(engine_sync, f'DROP TABLE IF EXISTS "{IMAGE_TABLE_SYNC}"')
 
     @pytest_asyncio.fixture(scope="class")
     async def image_uris(self):

--- a/tests/test_vectorstore.py
+++ b/tests/test_vectorstore.py
@@ -16,13 +16,14 @@ import asyncio
 import os
 import uuid
 from threading import Thread
-from typing import Sequence
+from typing import List, Sequence
 
 import pytest
 import pytest_asyncio
-from google.cloud.alloydb.connector import AsyncConnector, Connector, IPTypes
+from google.cloud.alloydb.connector import AsyncConnector, IPTypes
 from langchain_core.documents import Document
 from langchain_core.embeddings import DeterministicFakeEmbedding
+from PIL import Image
 from sqlalchemy import text
 from sqlalchemy.engine.row import RowMapping
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
@@ -32,6 +33,7 @@ from langchain_google_alloydb_pg import AlloyDBEngine, AlloyDBVectorStore, Colum
 DEFAULT_TABLE = "test_table" + str(uuid.uuid4())
 DEFAULT_TABLE_SYNC = "test_table_sync" + str(uuid.uuid4())
 CUSTOM_TABLE = "test-table-custom" + str(uuid.uuid4())
+IMAGE_TABLE_SYNC = "test_image_table_sync" + str(uuid.uuid4())
 VECTOR_SIZE = 768
 
 embeddings_service = DeterministicFakeEmbedding(size=VECTOR_SIZE)
@@ -44,6 +46,15 @@ docs = [
 ]
 
 embeddings = [embeddings_service.embed_query(texts[i]) for i in range(len(texts))]
+
+
+class FakeImageEmbedding(DeterministicFakeEmbedding):
+
+    def embed_image(self, image_paths: List[str]) -> List[List[float]]:
+        return [self.embed_query(path) for path in image_paths]
+
+
+image_embedding_service = FakeImageEmbedding(size=VECTOR_SIZE)
 
 
 def get_env_var(key: str, desc: str) -> str:
@@ -181,6 +192,35 @@ class TestVectorStore:
         yield vs
         await aexecute(engine, f'DROP TABLE IF EXISTS "{CUSTOM_TABLE}"')
 
+    @pytest_asyncio.fixture(scope="class")
+    async def image_vs_sync(self, engine_sync):
+        engine_sync.init_vectorstore_table(IMAGE_TABLE_SYNC, VECTOR_SIZE)
+        vs = AlloyDBVectorStore.create_sync(
+            engine_sync,
+            embedding_service=image_embedding_service,
+            table_name=IMAGE_TABLE_SYNC,
+        )
+        yield vs
+        engine_sync._execute(f'DROP TABLE IF EXISTS "{IMAGE_TABLE_SYNC}"')
+        engine_sync._engine.dispose()
+
+    @pytest_asyncio.fixture(scope="class")
+    async def image_uris(self):
+        image = Image.new("RGB", (100, 100), color="red")
+        image.save("test_image_red.jpg")
+        image = Image.new("RGB", (100, 100), color="green")
+        image.save("test_image_green.jpg")
+        image = Image.new("RGB", (100, 100), color="blue")
+        image.save("test_image_blue.jpg")
+        image_uris = [
+            "test_image_red.jpg",
+            "test_image_green.jpg",
+            "test_image_blue.jpg",
+        ]
+        yield image_uris
+        for uri in image_uris:
+            os.remove(uri)
+
     async def test_init_with_constructor(self, engine):
         with pytest.raises(Exception):
             AlloyDBVectorStore(
@@ -300,6 +340,18 @@ class TestVectorStore:
         assert results[0]["source"] == "google.com"
         await aexecute(engine, f'TRUNCATE TABLE "{CUSTOM_TABLE}"')
 
+    async def test_aadd_images(self, engine, image_vs, image_uris):
+        ids = [str(uuid.uuid4()) for i in range(len(image_uris))]
+        metadatas = [
+            {"image_id": str(i), "source": "google.com"} for i in range(len(image_uris))
+        ]
+        await image_vs.aadd_images(image_uris, metadatas, ids)
+        results = await engine._afetch(f'SELECT * FROM "{IMAGE_TABLE_SYNC}"')
+        assert len(results) == 3
+        assert results[0]["image_id"] == 0
+        assert results[0]["source"] == "google.com"
+        await engine._aexecute(f'TRUNCATE TABLE "{IMAGE_TABLE_SYNC}"')
+
     async def test_adelete_custom(self, engine, vs_custom):
         ids = [str(uuid.uuid4()) for i in range(len(texts))]
         await vs_custom.aadd_texts(texts, ids=ids)
@@ -330,6 +382,13 @@ class TestVectorStore:
         assert len(results) == 3
         await vs_sync.adelete(ids)
         await aexecute(engine_sync, f'TRUNCATE TABLE "{DEFAULT_TABLE_SYNC}"')
+
+    async def test_add_images(self, engine_sync, image_vs_sync, image_uris):
+        ids = [str(uuid.uuid4()) for i in range(len(image_uris))]
+        image_vs_sync.add_images(image_uris, ids=ids)
+        results = engine_sync._fetch(f'SELECT * FROM "{IMAGE_TABLE_SYNC}"')
+        assert len(results) == 3
+        await image_vs_sync.adelete(ids)
 
     async def test_cross_env(self, engine_sync, vs_sync):
         ids = [str(uuid.uuid4()) for i in range(len(texts))]

--- a/tests/test_vectorstore.py
+++ b/tests/test_vectorstore.py
@@ -339,17 +339,17 @@ class TestVectorStore:
         assert results[0]["source"] == "google.com"
         await aexecute(engine, f'TRUNCATE TABLE "{CUSTOM_TABLE}"')
 
-    async def test_aadd_images(self, engine, image_vs, image_uris):
+    async def test_aadd_images(self, engine, image_vs_sync, image_uris):
         ids = [str(uuid.uuid4()) for i in range(len(image_uris))]
         metadatas = [
             {"image_id": str(i), "source": "google.com"} for i in range(len(image_uris))
         ]
-        await image_vs.aadd_images(image_uris, metadatas, ids)
-        results = await engine._afetch(f'SELECT * FROM "{IMAGE_TABLE_SYNC}"')
+        await image_vs_sync.aadd_images(image_uris, metadatas, ids)
+        results = await afetch(engine, f'SELECT * FROM "{IMAGE_TABLE_SYNC}"')
         assert len(results) == 3
         assert results[0]["image_id"] == 0
         assert results[0]["source"] == "google.com"
-        await engine._aexecute(f'TRUNCATE TABLE "{IMAGE_TABLE_SYNC}"')
+        await aexecute(engine, f'TRUNCATE TABLE "{IMAGE_TABLE_SYNC}"')
 
     async def test_adelete_custom(self, engine, vs_custom):
         ids = [str(uuid.uuid4()) for i in range(len(texts))]
@@ -385,7 +385,7 @@ class TestVectorStore:
     async def test_add_images(self, engine_sync, image_vs_sync, image_uris):
         ids = [str(uuid.uuid4()) for i in range(len(image_uris))]
         image_vs_sync.add_images(image_uris, ids=ids)
-        results = engine_sync._fetch(f'SELECT * FROM "{IMAGE_TABLE_SYNC}"')
+        results = await afetch(engine_sync, (f'SELECT * FROM "{IMAGE_TABLE_SYNC}"'))
         assert len(results) == 3
         await image_vs_sync.adelete(ids)
 

--- a/tests/test_vectorstore.py
+++ b/tests/test_vectorstore.py
@@ -348,7 +348,7 @@ class TestVectorStore:
         await vs.aadd_images(image_uris, metadatas, ids)
         results = await afetch(engine_sync, f'SELECT * FROM "{IMAGE_TABLE}"')
         assert len(results) == 3
-        assert results[0]["image_id"] == ids[0]
+        assert results[0]["image_id"] == "0"
         assert results[0]["source"] == "google.com"
         await aexecute(engine_sync, f'TRUNCATE TABLE "{IMAGE_TABLE}"')
 

--- a/tests/test_vectorstore_search.py
+++ b/tests/test_vectorstore_search.py
@@ -109,7 +109,7 @@ class TestVectorStoreSearch:
 
     @pytest_asyncio.fixture(scope="class")
     async def vs(self, engine):
-        await engine._ainit_vectorstore_table(
+        await engine.ainit_vectorstore_table(
             DEFAULT_TABLE, VECTOR_SIZE, store_metadata=False
         )
         vs = await AlloyDBVectorStore.create(
@@ -182,7 +182,7 @@ class TestVectorStoreSearch:
 
     @pytest_asyncio.fixture(scope="class")
     async def image_vs(self, engine, image_uris):
-        await engine._ainit_vectorstore_table(IMAGE_TABLE_SYNC, VECTOR_SIZE)
+        await engine.ainit_vectorstore_table(IMAGE_TABLE_SYNC, VECTOR_SIZE)
         vs = await AlloyDBVectorStore.create(
             engine,
             embedding_service=image_embedding_service,

--- a/tests/test_vectorstore_search.py
+++ b/tests/test_vectorstore_search.py
@@ -29,7 +29,8 @@ from langchain_google_alloydb_pg.indexes import DistanceStrategy, HNSWQueryOptio
 DEFAULT_TABLE = "test_table" + str(uuid.uuid4()).replace("-", "_")
 DEFAULT_TABLE_SYNC = "test_table" + str(uuid.uuid4()).replace("-", "_")
 CUSTOM_TABLE = "test_table_custom" + str(uuid.uuid4()).replace("-", "_")
-IMAGE_TABLE_SYNC = "test_iamge_table" + str(uuid.uuid4()).replace("-", "_")
+IMAGE_TABLE = "test_image_table" + str(uuid.uuid4()).replace("-", "_")
+IMAGE_TABLE_SYNC = "test_image_table_sync" + str(uuid.uuid4()).replace("-", "_")
 VECTOR_SIZE = 768
 
 embeddings_service = DeterministicFakeEmbedding(size=VECTOR_SIZE)
@@ -166,15 +167,15 @@ class TestVectorStoreSearch:
     @pytest_asyncio.fixture(scope="class")
     async def image_uris(self):
         image = Image.new("RGB", (100, 100), color="red")
-        image.save("test_image_red_search.jpg")
+        image.save("test_image_red_search_async.jpg")
         image = Image.new("RGB", (100, 100), color="green")
-        image.save("test_image_green_search.jpg")
+        image.save("test_image_green_search_async.jpg")
         image = Image.new("RGB", (100, 100), color="blue")
-        image.save("test_image_blue_search.jpg")
+        image.save("test_image_blue_search_async.jpg")
         image_uris = [
-            "test_image_red_search.jpg",
-            "test_image_green_search.jpg",
-            "test_image_blue_search.jpg",
+            "test_image_red_search_async.jpg",
+            "test_image_green_search_async.jpg",
+            "test_image_blue_search_async.jpg",
         ]
         yield image_uris
         for uri in image_uris:
@@ -182,11 +183,11 @@ class TestVectorStoreSearch:
 
     @pytest_asyncio.fixture(scope="class")
     async def image_vs(self, engine, image_uris):
-        await engine.ainit_vectorstore_table(IMAGE_TABLE_SYNC, VECTOR_SIZE)
+        await engine.ainit_vectorstore_table(IMAGE_TABLE, VECTOR_SIZE)
         vs = await AlloyDBVectorStore.create(
             engine,
             embedding_service=image_embedding_service,
-            table_name=IMAGE_TABLE_SYNC,
+            table_name=IMAGE_TABLE,
             distance_strategy=DistanceStrategy.COSINE_DISTANCE,
         )
         ids = [str(uuid.uuid4()) for i in range(len(image_uris))]
@@ -348,17 +349,16 @@ class TestVectorStoreSearchSync:
 
     @pytest_asyncio.fixture(scope="class")
     async def image_uris(self):
+        red_uri = "test_image_red.jpg" + str(uuid.uuid4()).replace("-", "_")
+        green_uri = "test_image_green.jpg" + str(uuid.uuid4()).replace("-", "_")
+        blue_uri = "test_image_blue.jpg" + str(uuid.uuid4()).replace("-", "_")
         image = Image.new("RGB", (100, 100), color="red")
-        image.save("test_image_red_search.jpg")
+        image.save(red_uri)
         image = Image.new("RGB", (100, 100), color="green")
-        image.save("test_image_green_search.jpg")
+        image.save(green_uri)
         image = Image.new("RGB", (100, 100), color="blue")
-        image.save("test_image_blue_search.jpg")
-        image_uris = [
-            "test_image_red_search.jpg",
-            "test_image_green_search.jpg",
-            "test_image_blue_search.jpg",
-        ]
+        image.save(blue_uri)
+        image_uris = [red_uri, green_uri, blue_uri]
         yield image_uris
         for uri in image_uris:
             os.remove(uri)

--- a/tests/test_vectorstore_search.py
+++ b/tests/test_vectorstore_search.py
@@ -166,17 +166,16 @@ class TestVectorStoreSearch:
 
     @pytest_asyncio.fixture(scope="class")
     async def image_uris(self):
+        red_uri = str(uuid.uuid4()).replace("-", "_") + "test_image_red.jpg"
+        green_uri = str(uuid.uuid4()).replace("-", "_") + "test_image_green.jpg"
+        blue_uri = str(uuid.uuid4()).replace("-", "_") + "test_image_blue.jpg"
         image = Image.new("RGB", (100, 100), color="red")
-        image.save("test_image_red_search_async.jpg")
+        image.save(red_uri)
         image = Image.new("RGB", (100, 100), color="green")
-        image.save("test_image_green_search_async.jpg")
+        image.save(green_uri)
         image = Image.new("RGB", (100, 100), color="blue")
-        image.save("test_image_blue_search_async.jpg")
-        image_uris = [
-            "test_image_red_search_async.jpg",
-            "test_image_green_search_async.jpg",
-            "test_image_blue_search_async.jpg",
-        ]
+        image.save(blue_uri)
+        image_uris = [red_uri, green_uri, blue_uri]
         yield image_uris
         for uri in image_uris:
             os.remove(uri)
@@ -349,9 +348,9 @@ class TestVectorStoreSearchSync:
 
     @pytest_asyncio.fixture(scope="class")
     async def image_uris(self):
-        red_uri = "test_image_red.jpg" + str(uuid.uuid4()).replace("-", "_")
-        green_uri = "test_image_green.jpg" + str(uuid.uuid4()).replace("-", "_")
-        blue_uri = "test_image_blue.jpg" + str(uuid.uuid4()).replace("-", "_")
+        red_uri = str(uuid.uuid4()).replace("-", "_") + "test_image_red.jpg"
+        green_uri = str(uuid.uuid4()).replace("-", "_") + "test_image_green.jpg"
+        blue_uri = str(uuid.uuid4()).replace("-", "_") + "test_image_blue.jpg"
         image = Image.new("RGB", (100, 100), color="red")
         image.save(red_uri)
         image = Image.new("RGB", (100, 100), color="green")

--- a/tests/test_vectorstore_search.py
+++ b/tests/test_vectorstore_search.py
@@ -181,10 +181,10 @@ class TestVectorStoreSearch:
             os.remove(uri)
 
     @pytest_asyncio.fixture(scope="class")
-    async def image_vs(self, engine, image_uris):
-        engine.init_vectorstore_table(IMAGE_TABLE_SYNC, VECTOR_SIZE)
-        vs = AlloyDBVectorStore.create(
-            engine,
+    async def image_vs(self, engine_sync, image_uris):
+        engine_sync.init_vectorstore_table(IMAGE_TABLE_SYNC, VECTOR_SIZE)
+        vs = AlloyDBVectorStore.create_sync(
+            engine_sync,
             embedding_service=image_embedding_service,
             table_name=IMAGE_TABLE_SYNC,
             distance_strategy=DistanceStrategy.COSINE_DISTANCE,

--- a/tests/test_vectorstore_search.py
+++ b/tests/test_vectorstore_search.py
@@ -182,7 +182,7 @@ class TestVectorStoreSearch:
 
     @pytest_asyncio.fixture(scope="class")
     async def image_vs(self, engine, image_uris):
-        engine.ainit_vectorstore_table(IMAGE_TABLE_SYNC, VECTOR_SIZE)
+        engine.init_vectorstore_table(IMAGE_TABLE_SYNC, VECTOR_SIZE)
         vs = AlloyDBVectorStore.create(
             engine,
             embedding_service=image_embedding_service,


### PR DESCRIPTION
1. Add new image search APIs `similarity_search_image()` and `asimilarity_search_image()`.
2. Add `add_images()` and `aadd_images()` endpoints to add images to vector store.
3. Add tests.
