### PR TITLE
fix!: Update `postgres_ann` to `alloydb_scann`

### DIFF
--- a/docs/how_to_choose_an_index_guide.md
+++ b/docs/how_to_choose_an_index_guide.md
@@ -28,7 +28,7 @@ HNSW (through the pgvector extension)
 - Tree-based algorithms organize data in a structured, hierarchical manner, making them efficient for lower-dimensional datasets. They offer a structured and often more resource-efficient approach to partitioning space and finding neighbors, but their performance degrades when the embeddings have high dimensionality but low information density. Examples:
 IVF (through the pgvector++ extension)
 IVFFlat (through the pgvector extension)
-ScaNN (through the alloydb_scann extension)
+ScaNN (through the alloydb_scann extension available on AlloyDB Omni GA and AlloyDB Cloud private preview)
 
 Here is a comparison table between Graph-based and Tree-based Indexing algorithms:
 

--- a/docs/how_to_choose_an_index_guide.md
+++ b/docs/how_to_choose_an_index_guide.md
@@ -28,7 +28,7 @@ HNSW (through the pgvector extension)
 - Tree-based algorithms organize data in a structured, hierarchical manner, making them efficient for lower-dimensional datasets. They offer a structured and often more resource-efficient approach to partitioning space and finding neighbors, but their performance degrades when the embeddings have high dimensionality but low information density. Examples:
 IVF (through the pgvector++ extension)
 IVFFlat (through the pgvector extension)
-ScaNN (through the postgres_ann extension)
+ScaNN (through the alloydb_scann extension)
 
 Here is a comparison table between Graph-based and Tree-based Indexing algorithms:
 

--- a/src/langchain_google_alloydb_pg/vectorstore.py
+++ b/src/langchain_google_alloydb_pg/vectorstore.py
@@ -918,9 +918,9 @@ class AlloyDBVectorStore(VectorStore):
             await self.adrop_vector_index()
             return
 
-        # Create `postgres_ann` extension when a `ScaNN` index is applied
+        # Create `alloydb_scann` extension when a `ScaNN` index is applied
         if isinstance(index, ScaNNIndex):
-            await self.engine._aexecute("CREATE EXTENSION IF NOT EXISTS postgres_ann")
+            await self.engine._aexecute("CREATE EXTENSION IF NOT EXISTS alloydb_scann")
             function = index.distance_strategy.scann_index_function
         else:
             function = index.distance_strategy.index_function

--- a/tests/test_alloydb_vectorstore_index.py
+++ b/tests/test_alloydb_vectorstore_index.py
@@ -187,7 +187,7 @@ class TestIndex:
         await vs.adrop_vector_index("secondindex")
         await vs.adrop_vector_index()
 
-    async def test_aapply_postgres_ann_index_ScaNN(self, omni_vs):
+    async def test_aapply_alloydb_scann_index_ScaNN(self, omni_vs):
         index = ScaNNIndex(distance_strategy=DistanceStrategy.EUCLIDEAN)
         await omni_vs.set_maintenance_work_mem(index.num_leaves, VECTOR_SIZE)
         await omni_vs.aapply_vector_index(index, concurrently=True)


### PR DESCRIPTION
Breaking change!

Rename of `postgres_ann` extension (Current available on AlloyDB Omni GA and  available on AlloyDB Cloud as a private preview) to `alloydb_ann`. If using with Omni, update to the latest version of AlloyDB Omni use correctly. 