### PR TITLE
feat: allow non-uuid data types for vectorstore primary key

### DIFF
--- a/src/langchain_google_alloydb_pg/async_vectorstore.py
+++ b/src/langchain_google_alloydb_pg/async_vectorstore.py
@@ -222,10 +222,14 @@ class AsyncAlloyDBVectorStore(VectorStore):
         texts: Iterable[str],
         embeddings: List[List[float]],
         metadatas: Optional[List[dict]] = None,
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         **kwargs: Any,
     ) -> List[str]:
-        """Add data along with embeddings to the table."""
+        """Add data along with embeddings to the table.
+
+        Raises:
+            :class:`InvalidTextRepresentationError <asyncpg.exceptions.InvalidTextRepresentationError>`: if the `ids` data type does not match that of the `id_column`.
+        """
         if not ids:
             ids = [str(uuid.uuid4()) for _ in texts]
         if not metadatas:
@@ -272,10 +276,14 @@ class AsyncAlloyDBVectorStore(VectorStore):
         self,
         texts: Iterable[str],
         metadatas: Optional[List[dict]] = None,
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         **kwargs: Any,
     ) -> List[str]:
-        """Embed texts and add to the table."""
+        """Embed texts and add to the table.
+
+        Raises:
+            :class:`InvalidTextRepresentationError <asyncpg.exceptions.InvalidTextRepresentationError>`: if the `ids` data type does not match that of the `id_column`.
+        """
         embeddings = self.embedding_service.embed_documents(list(texts))
         ids = await self.aadd_embeddings(
             texts, embeddings, metadatas=metadatas, ids=ids, **kwargs
@@ -285,10 +293,14 @@ class AsyncAlloyDBVectorStore(VectorStore):
     async def aadd_documents(
         self,
         documents: List[Document],
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         **kwargs: Any,
     ) -> List[str]:
-        """Embed documents and add to the table."""
+        """Embed documents and add to the table.
+
+        Raises:
+            :class:`InvalidTextRepresentationError <asyncpg.exceptions.InvalidTextRepresentationError>`: if the `ids` data type does not match that of the `id_column`.
+        """
         texts = [doc.page_content for doc in documents]
         metadatas = [doc.metadata for doc in documents]
         ids = await self.aadd_texts(texts, metadatas=metadatas, ids=ids, **kwargs)
@@ -296,10 +308,14 @@ class AsyncAlloyDBVectorStore(VectorStore):
 
     async def adelete(
         self,
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         **kwargs: Any,
     ) -> Optional[bool]:
-        """Delete records from the table."""
+        """Delete records from the table.
+
+        Raises:
+            :class:`InvalidTextRepresentationError <asyncpg.exceptions.InvalidTextRepresentationError>`: if the `ids` data type does not match that of the `id_column`.
+        """
         if not ids:
             return False
 
@@ -319,7 +335,7 @@ class AsyncAlloyDBVectorStore(VectorStore):
         table_name: str,
         schema_name: str = "public",
         metadatas: Optional[List[dict]] = None,
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         content_column: str = "content",
         embedding_column: str = "embedding",
         metadata_columns: List[str] = [],
@@ -354,6 +370,9 @@ class AsyncAlloyDBVectorStore(VectorStore):
             lambda_mult (float): Number between 0 and 1 that determines the degree of diversity among the results with 0 corresponding to maximum diversity and 1 to minimum diversity. Defaults to 0.5.
             index_query_options (QueryOptions): Index query option.
 
+        Raises:
+            :class:`InvalidTextRepresentationError <asyncpg.exceptions.InvalidTextRepresentationError>`: if the `ids` data type does not match that of the `id_column`.
+
         Returns:
             AsyncAlloyDBVectorStore
         """
@@ -385,7 +404,7 @@ class AsyncAlloyDBVectorStore(VectorStore):
         engine: AlloyDBEngine,
         table_name: str,
         schema_name: str = "public",
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         content_column: str = "content",
         embedding_column: str = "embedding",
         metadata_columns: List[str] = [],
@@ -419,6 +438,9 @@ class AsyncAlloyDBVectorStore(VectorStore):
             fetch_k (int): Number of Documents to fetch to pass to MMR algorithm.
             lambda_mult (float): Number between 0 and 1 that determines the degree of diversity among the results with 0 corresponding to maximum diversity and 1 to minimum diversity. Defaults to 0.5.
             index_query_options (QueryOptions): Index query option.
+
+        Raises:
+            :class:`InvalidTextRepresentationError <asyncpg.exceptions.InvalidTextRepresentationError>`: if the `ids` data type does not match that of the `id_column`.
 
         Returns:
             AsyncAlloyDBVectorStore
@@ -749,7 +771,7 @@ class AsyncAlloyDBVectorStore(VectorStore):
         self,
         texts: Iterable[str],
         metadatas: Optional[List[dict]] = None,
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         **kwargs: Any,
     ) -> List[str]:
         raise NotImplementedError(
@@ -759,7 +781,7 @@ class AsyncAlloyDBVectorStore(VectorStore):
     def add_documents(
         self,
         documents: List[Document],
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         **kwargs: Any,
     ) -> List[str]:
         raise NotImplementedError(
@@ -768,7 +790,7 @@ class AsyncAlloyDBVectorStore(VectorStore):
 
     def delete(
         self,
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         **kwargs: Any,
     ) -> Optional[bool]:
         raise NotImplementedError(
@@ -783,7 +805,7 @@ class AsyncAlloyDBVectorStore(VectorStore):
         engine: AlloyDBEngine,
         table_name: str,
         metadatas: Optional[List[dict]] = None,
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         content_column: str = "content",
         embedding_column: str = "embedding",
         metadata_columns: List[str] = [],
@@ -803,7 +825,7 @@ class AsyncAlloyDBVectorStore(VectorStore):
         embedding: Embeddings,
         engine: AlloyDBEngine,
         table_name: str,
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         content_column: str = "content",
         embedding_column: str = "embedding",
         metadata_columns: List[str] = [],

--- a/src/langchain_google_alloydb_pg/engine.py
+++ b/src/langchain_google_alloydb_pg/engine.py
@@ -420,7 +420,7 @@ class AlloyDBEngine:
         embedding_column: str = "embedding",
         metadata_columns: List[Column] = [],
         metadata_json_column: str = "langchain_metadata",
-        id_column: str = "langchain_id",
+        id_column: Union[str, Column] = "langchain_id",
         overwrite_existing: bool = False,
         store_metadata: bool = True,
     ) -> None:
@@ -440,14 +440,15 @@ class AlloyDBEngine:
                 metadata. Default: []. Optional.
             metadata_json_column (str): The column to store extra metadata in JSON format.
                 Default: "langchain_metadata". Optional.
-            id_column (str):  Name of the column to store ids.
-                Default: "langchain_id". Optional,
+            id_column (Union[str, Column]) :  Column to store ids.
+                Default: "langchain_id" column name with data type UUID. Optional.
             overwrite_existing (bool): Whether to drop existing table. Default: False.
             store_metadata (bool): Whether to store metadata in the table.
                 Default: True.
 
         Raises:
-            :class:`DuplicateTableError <asyncpg.exceptions.DuplicateTableError>`: if table already exists and overwrite flag is not set.
+            :class:`DuplicateTableError <asyncpg.exceptions.DuplicateTableError>`: if table already exists.
+            :class:`UndefinedObjectError <asyncpg.exceptions.UndefinedObjectError>`: if the data type of the id column is not a postgreSQL data type.
         """
         async with self._pool.connect() as conn:
             await conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
@@ -460,8 +461,11 @@ class AlloyDBEngine:
                 )
                 await conn.commit()
 
+        id_data_type = "UUID" if isinstance(id_column, str) else id_column.data_type
+        id_column_name = id_column if isinstance(id_column, str) else id_column.name
+
         query = f"""CREATE TABLE "{schema_name}"."{table_name}"(
-            "{id_column}" UUID PRIMARY KEY,
+            "{id_column_name}" {id_data_type} PRIMARY KEY,
             "{content_column}" TEXT NOT NULL,
             "{embedding_column}" vector({vector_size}) NOT NULL"""
         for column in metadata_columns:
@@ -484,7 +488,7 @@ class AlloyDBEngine:
         embedding_column: str = "embedding",
         metadata_columns: List[Column] = [],
         metadata_json_column: str = "langchain_metadata",
-        id_column: str = "langchain_id",
+        id_column: Union[str, Column] = "langchain_id",
         overwrite_existing: bool = False,
         store_metadata: bool = True,
     ) -> None:
@@ -504,8 +508,8 @@ class AlloyDBEngine:
                 metadata. Default: []. Optional.
             metadata_json_column (str): The column to store extra metadata in JSON format.
                 Default: "langchain_metadata". Optional.
-            id_column (str):  Name of the column to store ids.
-                Default: "langchain_id". Optional,
+            id_column (Union[str, Column]) :  Column to store ids.
+                Default: "langchain_id" column name with data type UUID. Optional.
             overwrite_existing (bool): Whether to drop existing table. Default: False.
             store_metadata (bool): Whether to store metadata in the table.
                 Default: True.
@@ -534,7 +538,7 @@ class AlloyDBEngine:
         embedding_column: str = "embedding",
         metadata_columns: List[Column] = [],
         metadata_json_column: str = "langchain_metadata",
-        id_column: str = "langchain_id",
+        id_column: Union[str, Column] = "langchain_id",
         overwrite_existing: bool = False,
         store_metadata: bool = True,
     ) -> None:
@@ -554,8 +558,8 @@ class AlloyDBEngine:
                 metadata. Default: []. Optional.
             metadata_json_column (str): The column to store extra metadata in JSON format.
                 Default: "langchain_metadata". Optional.
-            id_column (str):  Name of the column to store ids.
-                Default: "langchain_id". Optional,
+            id_column (Union[str, Column]) :  Column to store ids.
+                Default: "langchain_id" column name with data type UUID. Optional.
             overwrite_existing (bool): Whether to drop existing table. Default: False.
             store_metadata (bool): Whether to store metadata in the table.
                 Default: True.

--- a/src/langchain_google_alloydb_pg/vectorstore.py
+++ b/src/langchain_google_alloydb_pg/vectorstore.py
@@ -199,10 +199,14 @@ class AlloyDBVectorStore(VectorStore):
         self,
         texts: Iterable[str],
         metadatas: Optional[List[dict]] = None,
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         **kwargs: Any,
     ) -> List[str]:
-        """Embed texts and add to the table."""
+        """Embed texts and add to the table.
+
+        Raises:
+            :class:`InvalidTextRepresentationError <asyncpg.exceptions.InvalidTextRepresentationError>`: if the `ids` data type does not match that of the `id_column`.
+        """
         return await self._engine._run_as_async(
             self.__vs.aadd_texts(texts, metadatas, ids, **kwargs)
         )
@@ -210,10 +214,14 @@ class AlloyDBVectorStore(VectorStore):
     async def aadd_documents(
         self,
         documents: List[Document],
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         **kwargs: Any,
     ) -> List[str]:
-        """Embed documents and add to the table"""
+        """Embed documents and add to the table.
+
+        Raises:
+            :class:`InvalidTextRepresentationError <asyncpg.exceptions.InvalidTextRepresentationError>`: if the `ids` data type does not match that of the `id_column`.
+        """
         return await self._engine._run_as_async(
             self.__vs.aadd_documents(documents, ids, **kwargs)
         )
@@ -235,10 +243,14 @@ class AlloyDBVectorStore(VectorStore):
         self,
         texts: Iterable[str],
         metadatas: Optional[List[dict]] = None,
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         **kwargs: Any,
     ) -> List[str]:
-        """Embed texts and add to the table."""
+        """Embed texts and add to the table.
+
+        Raises:
+            :class:`InvalidTextRepresentationError <asyncpg.exceptions.InvalidTextRepresentationError>`: if the `ids` data type does not match that of the `id_column`.
+        """
         return self._engine._run_as_sync(
             self.__vs.aadd_texts(texts, metadatas, ids, **kwargs)
         )
@@ -246,28 +258,40 @@ class AlloyDBVectorStore(VectorStore):
     def add_documents(
         self,
         documents: List[Document],
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         **kwargs: Any,
     ) -> List[str]:
-        """Embed documents and add to the table."""
+        """Embed documents and add to the table.
+
+        Raises:
+            :class:`InvalidTextRepresentationError <asyncpg.exceptions.InvalidTextRepresentationError>`: if the `ids` data type does not match that of the `id_column`.
+        """
         return self._engine._run_as_sync(
             self.__vs.aadd_documents(documents, ids, **kwargs)
         )
 
     async def adelete(
         self,
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         **kwargs: Any,
     ) -> Optional[bool]:
-        """Delete records from the table."""
+        """Delete records from the table.
+
+        Raises:
+            :class:`InvalidTextRepresentationError <asyncpg.exceptions.InvalidTextRepresentationError>`: if the `ids` data type does not match that of the `id_column`.
+        """
         return await self._engine._run_as_async(self.__vs.adelete(ids, **kwargs))
 
     def delete(
         self,
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         **kwargs: Any,
     ) -> Optional[bool]:
-        """Delete records from the table."""
+        """Delete records from the table.
+
+        Raises:
+            :class:`InvalidTextRepresentationError <asyncpg.exceptions.InvalidTextRepresentationError>`: if the `ids` data type does not match that of the `id_column`.
+        """
         return self._engine._run_as_sync(self.__vs.adelete(ids, **kwargs))
 
     @classmethod
@@ -279,7 +303,7 @@ class AlloyDBVectorStore(VectorStore):
         table_name: str,
         schema_name: str = "public",
         metadatas: Optional[List[dict]] = None,
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         content_column: str = "content",
         embedding_column: str = "embedding",
         metadata_columns: List[str] = [],
@@ -302,7 +326,7 @@ class AlloyDBVectorStore(VectorStore):
             table_name (str): Name of an existing table.
             schema_name (str, optional): Name of the database schema. Defaults to "public".
             metadatas (Optional[List[dict]], optional): List of metadatas to add to table records. Defaults to None.
-            ids: (Optional[List[str]], optional): List of IDs to add to table records. Defaults to None.
+            ids: (Optional[List]): List of IDs to add to table records. Defaults to None.
             content_column (str, optional): Column that represent a Document’s page_content. Defaults to "content".
             embedding_column (str, optional): Column for embedding vectors. The embedding is generated from the document value. Defaults to "embedding".
             metadata_columns (List[str], optional): Column(s) that represent a document's metadata. Defaults to an empty list.
@@ -314,6 +338,9 @@ class AlloyDBVectorStore(VectorStore):
             fetch_k (int): Number of Documents to fetch to pass to MMR algorithm.
             lambda_mult (float): Number between 0 and 1 that determines the degree of diversity among the results with 0 corresponding to maximum diversity and 1 to minimum diversity. Defaults to 0.5.
             index_query_options (QueryOptions): Index query option.
+
+        Raises:
+            :class:`InvalidTextRepresentationError <asyncpg.exceptions.InvalidTextRepresentationError>`: if the `ids` data type does not match that of the `id_column`.
 
         Returns:
             AlloyDBVectorStore
@@ -346,7 +373,7 @@ class AlloyDBVectorStore(VectorStore):
         engine: AlloyDBEngine,
         table_name: str,
         schema_name: str = "public",
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         content_column: str = "content",
         embedding_column: str = "embedding",
         metadata_columns: List[str] = [],
@@ -368,7 +395,7 @@ class AlloyDBVectorStore(VectorStore):
             engine (AlloyDBEngine): Connection pool engine for managing connections to AlloyDB database.
             table_name (str): Name of an existing table.
             schema_name (str, optional): Name of the database schema. Defaults to "public".
-            ids: (Optional[List[str]], optional): List of IDs to add to table records. Defaults to None.
+            ids: (Optional[List]): List of IDs to add to table records. Defaults to None.
             content_column (str, optional): Column that represent a Document’s page_content. Defaults to "content".
             embedding_column (str, optional): Column for embedding vectors. The embedding is generated from the document value. Defaults to "embedding".
             metadata_columns (List[str], optional): Column(s) that represent a document's metadata. Defaults to an empty list.
@@ -380,6 +407,9 @@ class AlloyDBVectorStore(VectorStore):
             fetch_k (int): Number of Documents to fetch to pass to MMR algorithm.
             lambda_mult (float): Number between 0 and 1 that determines the degree of diversity among the results with 0 corresponding to maximum diversity and 1 to minimum diversity. Defaults to 0.5.
             index_query_options (QueryOptions): Index query option.
+
+        Raises:
+            :class:`InvalidTextRepresentationError <asyncpg.exceptions.InvalidTextRepresentationError>`: if the `ids` data type does not match that of the `id_column`.
 
         Returns:
             AlloyDBVectorStore
@@ -414,7 +444,7 @@ class AlloyDBVectorStore(VectorStore):
         table_name: str,
         schema_name: str = "public",
         metadatas: Optional[List[dict]] = None,
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         content_column: str = "content",
         embedding_column: str = "embedding",
         metadata_columns: List[str] = [],
@@ -437,7 +467,7 @@ class AlloyDBVectorStore(VectorStore):
             table_name (str): Name of an existing table.
             schema_name (str, optional): Name of the database schema. Defaults to "public".
             metadatas (Optional[List[dict]], optional): List of metadatas to add to table records. Defaults to None.
-            ids: (Optional[List[str]], optional): List of IDs to add to table records. Defaults to None.
+            ids: (Optional[List]): List of IDs to add to table records. Defaults to None.
             content_column (str, optional): Column that represent a Document’s page_content. Defaults to "content".
             embedding_column (str, optional): Column for embedding vectors. The embedding is generated from the document value. Defaults to "embedding".
             metadata_columns (List[str], optional): Column(s) that represent a document's metadata. Defaults to empty list.
@@ -449,6 +479,9 @@ class AlloyDBVectorStore(VectorStore):
             fetch_k (int): Number of Documents to fetch to pass to MMR algorithm.
             lambda_mult (float): Number between 0 and 1 that determines the degree of diversity among the results with 0 corresponding to maximum diversity and 1 to minimum diversity. Defaults to 0.5.
             index_query_options (QueryOptions): Index query option.
+
+        Raises:
+            :class:`InvalidTextRepresentationError <asyncpg.exceptions.InvalidTextRepresentationError>`: if the `ids` data type does not match that of the `id_column`.
 
         Returns:
             AlloyDBVectorStore
@@ -482,7 +515,7 @@ class AlloyDBVectorStore(VectorStore):
         engine: AlloyDBEngine,
         table_name: str,
         schema_name: str = "public",
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         content_column: str = "content",
         embedding_column: str = "embedding",
         metadata_columns: List[str] = [],
@@ -504,7 +537,7 @@ class AlloyDBVectorStore(VectorStore):
             engine (AlloyDBEngine): Connection pool engine for managing connections to AlloyDB database.
             table_name (str): Name of an existing table.
             schema_name (str, optional): Name of the database schema. Defaults to "public".
-            ids: (Optional[List[str]], optional): List of IDs to add to table records. Defaults to None.
+            ids: (Optional[List]): List of IDs to add to table records. Defaults to None.
             content_column (str, optional): Column that represent a Document’s page_content. Defaults to "content".
             embedding_column (str, optional): Column for embedding vectors. The embedding is generated from the document value. Defaults to "embedding".
             metadata_columns (List[str], optional): Column(s) that represent a document's metadata. Defaults to an empty list.
@@ -516,6 +549,9 @@ class AlloyDBVectorStore(VectorStore):
             fetch_k (int): Number of Documents to fetch to pass to MMR algorithm.
             lambda_mult (float): Number between 0 and 1 that determines the degree of diversity among the results with 0 corresponding to maximum diversity and 1 to minimum diversity. Defaults to 0.5.
             index_query_options (QueryOptions): Index query option.
+
+        Raises:
+            :class:`InvalidTextRepresentationError <asyncpg.exceptions.InvalidTextRepresentationError>`: if the `ids` data type does not match that of the `id_column`.
 
         Returns:
             AlloyDBVectorStore

--- a/tests/test_async_vectorstore_from_methods.py
+++ b/tests/test_async_vectorstore_from_methods.py
@@ -29,6 +29,9 @@ from langchain_google_alloydb_pg.async_vectorstore import AsyncAlloyDBVectorStor
 DEFAULT_TABLE = "test_table" + str(uuid.uuid4()).replace("-", "_")
 DEFAULT_TABLE_SYNC = "test_table_sync" + str(uuid.uuid4()).replace("-", "_")
 CUSTOM_TABLE = "test_table_custom" + str(uuid.uuid4()).replace("-", "_")
+CUSTOM_TABLE_WITH_INT_ID = "test_table_with_int_id" + str(uuid.uuid4()).replace(
+    "-", "_"
+)
 VECTOR_SIZE = 768
 
 
@@ -105,9 +108,19 @@ class TestVectorStoreFromMethods:
             metadata_columns=[Column("page", "TEXT"), Column("source", "TEXT")],
             store_metadata=False,
         )
+        await engine._ainit_vectorstore_table(
+            CUSTOM_TABLE_WITH_INT_ID,
+            VECTOR_SIZE,
+            id_column=Column(name="integer_id", data_type="INTEGER", nullable="False"),
+            content_column="mycontent",
+            embedding_column="myembedding",
+            metadata_columns=[Column("page", "TEXT"), Column("source", "TEXT")],
+            store_metadata=False,
+        )
         yield engine
         await aexecute(engine, f"DROP TABLE IF EXISTS {DEFAULT_TABLE}")
         await aexecute(engine, f"DROP TABLE IF EXISTS {CUSTOM_TABLE}")
+        await aexecute(engine, f"DROP TABLE IF EXISTS {CUSTOM_TABLE_WITH_INT_ID}")
         await engine.close()
 
     async def test_afrom_texts(self, engine):
@@ -185,3 +198,30 @@ class TestVectorStoreFromMethods:
         assert results[0]["page"] == "0"
         assert results[0]["source"] == "google.com"
         await aexecute(engine, f"TRUNCATE TABLE {CUSTOM_TABLE}")
+
+    async def test_afrom_docs_custom_with_int_id(self, engine):
+        ids = [i for i in range(len(texts))]
+        docs = [
+            Document(
+                page_content=texts[i],
+                metadata={"page": str(i), "source": "google.com"},
+            )
+            for i in range(len(texts))
+        ]
+        await AsyncAlloyDBVectorStore.afrom_documents(
+            docs,
+            embeddings_service,
+            engine,
+            CUSTOM_TABLE_WITH_INT_ID,
+            ids=ids,
+            id_column="integer_id",
+            content_column="mycontent",
+            embedding_column="myembedding",
+            metadata_columns=["page", "source"],
+        )
+
+        results = await afetch(engine, f"SELECT * FROM {CUSTOM_TABLE_WITH_INT_ID}")
+        assert len(results) == 3
+        for row in results:
+            assert isinstance(row["integer_id"], int)
+        await aexecute(engine, f"TRUNCATE TABLE {CUSTOM_TABLE_WITH_INT_ID}")

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -31,8 +31,12 @@ from langchain_google_alloydb_pg import AlloyDBEngine, Column
 
 DEFAULT_TABLE = "test_table" + str(uuid.uuid4()).replace("-", "_")
 CUSTOM_TABLE = "test_table_custom" + str(uuid.uuid4()).replace("-", "_")
+INT_ID_CUSTOM_TABLE = "test_table_custom_int_id" + str(uuid.uuid4()).replace("-", "_")
 DEFAULT_TABLE_SYNC = "test_table" + str(uuid.uuid4()).replace("-", "_")
 CUSTOM_TABLE_SYNC = "test_table_custom" + str(uuid.uuid4()).replace("-", "_")
+INT_ID_CUSTOM_TABLE_SYNC = "test_table_custom_int_id" + str(uuid.uuid4()).replace(
+    "-", "_"
+)
 VECTOR_SIZE = 768
 
 embeddings_service = DeterministicFakeEmbedding(size=VECTOR_SIZE)
@@ -115,6 +119,7 @@ class TestEngineAsync:
         yield engine
         await aexecute(engine, f'DROP TABLE "{CUSTOM_TABLE}"')
         await aexecute(engine, f'DROP TABLE "{DEFAULT_TABLE}"')
+        await aexecute(engine, f'DROP TABLE "{INT_ID_CUSTOM_TABLE}"')
         await engine.close()
 
     async def test_init_table(self, engine):
@@ -139,6 +144,29 @@ class TestEngineAsync:
         results = await afetch(engine, stmt)
         expected = [
             {"column_name": "uuid", "data_type": "uuid"},
+            {"column_name": "my_embedding", "data_type": "USER-DEFINED"},
+            {"column_name": "langchain_metadata", "data_type": "json"},
+            {"column_name": "my-content", "data_type": "text"},
+            {"column_name": "page", "data_type": "text"},
+            {"column_name": "source", "data_type": "text"},
+        ]
+        for row in results:
+            assert row in expected
+
+    async def test_init_table_with_int_id(self, engine):
+        await engine.ainit_vectorstore_table(
+            INT_ID_CUSTOM_TABLE,
+            VECTOR_SIZE,
+            id_column=Column(name="integer_id", data_type="INTEGER", nullable="False"),
+            content_column="my-content",
+            embedding_column="my_embedding",
+            metadata_columns=[Column("page", "TEXT"), Column("source", "TEXT")],
+            store_metadata=True,
+        )
+        stmt = f"SELECT column_name, data_type FROM information_schema.columns WHERE table_name = '{INT_ID_CUSTOM_TABLE}';"
+        results = await afetch(engine, stmt)
+        expected = [
+            {"column_name": "integer_id", "data_type": "integer"},
             {"column_name": "my_embedding", "data_type": "USER-DEFINED"},
             {"column_name": "langchain_metadata", "data_type": "json"},
             {"column_name": "my-content", "data_type": "text"},
@@ -321,6 +349,7 @@ class TestEngineSync:
         yield engine
         await aexecute(engine, f'DROP TABLE "{CUSTOM_TABLE_SYNC}"')
         await aexecute(engine, f'DROP TABLE "{DEFAULT_TABLE_SYNC}"')
+        await aexecute(engine, f'DROP TABLE "{INT_ID_CUSTOM_TABLE_SYNC}"')
         await engine.close()
 
     async def test_init_table(self, engine):
@@ -345,6 +374,29 @@ class TestEngineSync:
         results = await afetch(engine, stmt)
         expected = [
             {"column_name": "uuid", "data_type": "uuid"},
+            {"column_name": "my_embedding", "data_type": "USER-DEFINED"},
+            {"column_name": "langchain_metadata", "data_type": "json"},
+            {"column_name": "my-content", "data_type": "text"},
+            {"column_name": "page", "data_type": "text"},
+            {"column_name": "source", "data_type": "text"},
+        ]
+        for row in results:
+            assert row in expected
+
+    async def test_init_table_with_int_id(self, engine):
+        engine.init_vectorstore_table(
+            INT_ID_CUSTOM_TABLE_SYNC,
+            VECTOR_SIZE,
+            id_column=Column(name="integer_id", data_type="INTEGER", nullable="False"),
+            content_column="my-content",
+            embedding_column="my_embedding",
+            metadata_columns=[Column("page", "TEXT"), Column("source", "TEXT")],
+            store_metadata=True,
+        )
+        stmt = f"SELECT column_name, data_type FROM information_schema.columns WHERE table_name = '{INT_ID_CUSTOM_TABLE_SYNC}';"
+        results = await afetch(engine, stmt)
+        expected = [
+            {"column_name": "integer_id", "data_type": "integer"},
             {"column_name": "my_embedding", "data_type": "USER-DEFINED"},
             {"column_name": "langchain_metadata", "data_type": "json"},
             {"column_name": "my-content", "data_type": "text"},

--- a/tests/test_vectorstore_from_methods.py
+++ b/tests/test_vectorstore_from_methods.py
@@ -29,6 +29,12 @@ from langchain_google_alloydb_pg import AlloyDBEngine, AlloyDBVectorStore, Colum
 DEFAULT_TABLE = "test_table" + str(uuid.uuid4()).replace("-", "_")
 DEFAULT_TABLE_SYNC = "test_table_sync" + str(uuid.uuid4()).replace("-", "_")
 CUSTOM_TABLE = "test_table_custom" + str(uuid.uuid4()).replace("-", "_")
+CUSTOM_TABLE_WITH_INT_ID = "test_table_with_int_id" + str(uuid.uuid4()).replace(
+    "-", "_"
+)
+CUSTOM_TABLE_WITH_INT_ID_SYNC = "test_table_with_int_id" + str(uuid.uuid4()).replace(
+    "-", "_"
+)
 VECTOR_SIZE = 768
 
 
@@ -114,9 +120,19 @@ class TestVectorStoreFromMethods:
             metadata_columns=[Column("page", "TEXT"), Column("source", "TEXT")],
             store_metadata=False,
         )
+        await engine.ainit_vectorstore_table(
+            CUSTOM_TABLE_WITH_INT_ID,
+            VECTOR_SIZE,
+            id_column=Column(name="integer_id", data_type="INTEGER", nullable="False"),
+            content_column="mycontent",
+            embedding_column="myembedding",
+            metadata_columns=[Column("page", "TEXT"), Column("source", "TEXT")],
+            store_metadata=False,
+        )
         yield engine
         await aexecute(engine, f"DROP TABLE IF EXISTS {DEFAULT_TABLE}")
         await aexecute(engine, f"DROP TABLE IF EXISTS {CUSTOM_TABLE}")
+        await aexecute(engine, f"DROP TABLE IF EXISTS {CUSTOM_TABLE_WITH_INT_ID}")
         await engine.close()
 
     @pytest_asyncio.fixture
@@ -131,9 +147,19 @@ class TestVectorStoreFromMethods:
             database=db_name,
         )
         engine.init_vectorstore_table(DEFAULT_TABLE_SYNC, VECTOR_SIZE)
+        engine.init_vectorstore_table(
+            CUSTOM_TABLE_WITH_INT_ID_SYNC,
+            VECTOR_SIZE,
+            id_column=Column(name="integer_id", data_type="INTEGER", nullable="False"),
+            content_column="mycontent",
+            embedding_column="myembedding",
+            metadata_columns=[Column("page", "TEXT"), Column("source", "TEXT")],
+            store_metadata=False,
+        )
 
         yield engine
         await aexecute(engine, f"DROP TABLE IF EXISTS {DEFAULT_TABLE_SYNC}")
+        await aexecute(engine, f"DROP TABLE IF EXISTS {CUSTOM_TABLE_WITH_INT_ID_SYNC}")
         await engine.close()
 
     async def test_afrom_texts(self, engine):
@@ -264,3 +290,44 @@ class TestVectorStoreFromMethods:
         assert results[0]["page"] == "0"
         assert results[0]["source"] == "google.com"
         await aexecute(engine, f"TRUNCATE TABLE {CUSTOM_TABLE}")
+
+    async def test_afrom_texts_custom_with_int_id(self, engine):
+        ids = [i for i in range(len(texts))]
+        await AlloyDBVectorStore.afrom_texts(
+            texts,
+            embeddings_service,
+            engine,
+            CUSTOM_TABLE_WITH_INT_ID,
+            metadatas=metadatas,
+            ids=ids,
+            id_column="integer_id",
+            content_column="mycontent",
+            embedding_column="myembedding",
+            metadata_columns=["page", "source"],
+        )
+        results = await afetch(engine, f"SELECT * FROM {CUSTOM_TABLE_WITH_INT_ID}")
+        assert len(results) == 3
+        for row in results:
+            assert isinstance(row["integer_id"], int)
+        await aexecute(engine, f"TRUNCATE TABLE {CUSTOM_TABLE_WITH_INT_ID}")
+
+    async def test_from_texts_custom_with_int_id(self, engine_sync):
+        ids = [i for i in range(len(texts))]
+        AlloyDBVectorStore.from_texts(
+            texts,
+            embeddings_service,
+            engine_sync,
+            CUSTOM_TABLE_WITH_INT_ID_SYNC,
+            ids=ids,
+            id_column="integer_id",
+            content_column="mycontent",
+            embedding_column="myembedding",
+            metadata_columns=["page", "source"],
+        )
+        results = await afetch(
+            engine_sync, f"SELECT * FROM {CUSTOM_TABLE_WITH_INT_ID_SYNC}"
+        )
+        assert len(results) == 3
+        for row in results:
+            assert isinstance(row["integer_id"], int)
+        await aexecute(engine_sync, f"TRUNCATE TABLE {CUSTOM_TABLE_WITH_INT_ID_SYNC}")


### PR DESCRIPTION
feat: allow non-uuid data types for vectorstore primary key
