### PR TITLE
feat: Add GCS URI support for image embedding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ authors = [
 ]
 dependencies = [
     "google-cloud-alloydb-connector[asyncpg]>=1.2.0, <2.0.0",
+    "google-cloud-storage>=2.18.2, <3.0.0",
     "langchain-core>=0.2.36, <1.0.0",
     "numpy>=1.24.4, <2.0.0",
     "pgvector>=0.2.5, <1.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 google-cloud-alloydb-connector[asyncpg]==1.4.0
+google-cloud-storage>=2.18.2, <3.0.0
 langchain-core==0.3.0
 numpy==1.26.4
 pgvector==0.3.3

--- a/src/langchain_google_alloydb_pg/async_vectorstore.py
+++ b/src/langchain_google_alloydb_pg/async_vectorstore.py
@@ -548,8 +548,15 @@ class AsyncAlloyDBVectorStore(VectorStore):
         )
 
     def _images_embedding_helper(self, image_uris: List[str]) -> List[List[float]]:
-        # check if `embed_image()` API is supported by the embedding service used
-        if hasattr(self.embedding_service, "embed_image"):
+        # check if either `embed_images()` or `embed_image()` API is supported by the embedding service used
+        if hasattr(self.embedding_service, "embed_images"):
+            try:
+                embeddings = self.embedding_service.embed_images(image_uris)
+            except Exception as e:
+                raise Exception(
+                    f"Make sure your selected embedding model supports list of image URIs as input. {str(e)}"
+                )
+        elif hasattr(self.embedding_service, "embed_image"):
             try:
                 embeddings = self.embedding_service.embed_image(image_uris)
             except Exception as e:

--- a/tests/test_async_vectorstore.py
+++ b/tests/test_async_vectorstore.py
@@ -175,7 +175,10 @@ class TestVectorStore:
         image_uris = [red_uri, green_uri, blue_uri, gcs_uri]
         yield image_uris
         for uri in image_uris:
-            os.remove(uri)
+            try:
+                os.remove(uri)
+            except FileNotFoundError:
+                pass
 
     async def test_init_with_constructor(self, engine):
         with pytest.raises(Exception):

--- a/tests/test_async_vectorstore.py
+++ b/tests/test_async_vectorstore.py
@@ -165,13 +165,14 @@ class TestVectorStore:
         red_uri = str(uuid.uuid4()).replace("-", "_") + "test_image_red.jpg"
         green_uri = str(uuid.uuid4()).replace("-", "_") + "test_image_green.jpg"
         blue_uri = str(uuid.uuid4()).replace("-", "_") + "test_image_blue.jpg"
+        gcs_uri = "gs://github-repo/img/vision/google-cloud-next.jpeg"
         image = Image.new("RGB", (100, 100), color="red")
         image.save(red_uri)
         image = Image.new("RGB", (100, 100), color="green")
         image.save(green_uri)
         image = Image.new("RGB", (100, 100), color="blue")
         image.save(blue_uri)
-        image_uris = [red_uri, green_uri, blue_uri]
+        image_uris = [red_uri, green_uri, blue_uri, gcs_uri]
         yield image_uris
         for uri in image_uris:
             os.remove(uri)
@@ -242,7 +243,7 @@ class TestVectorStore:
         ]
         await image_vs.aadd_images(image_uris, metadatas, ids)
         results = await afetch(engine, (f'SELECT * FROM "{IMAGE_TABLE}"'))
-        assert len(results) == 3
+        assert len(results) == 4
         assert results[0]["image_id"] == "0"
         assert results[0]["source"] == "google.com"
         await aexecute(engine, (f'TRUNCATE TABLE "{IMAGE_TABLE}"'))

--- a/tests/test_async_vectorstore_search.py
+++ b/tests/test_async_vectorstore_search.py
@@ -161,7 +161,10 @@ class TestVectorStoreSearch:
         image_uris = [red_uri, green_uri, blue_uri, gcs_uri]
         yield image_uris
         for uri in image_uris:
-            os.remove(uri)
+            try:
+                os.remove(uri)
+            except FileNotFoundError:
+                pass
 
     @pytest_asyncio.fixture(scope="class")
     async def image_vs(self, engine, image_uris):

--- a/tests/test_async_vectorstore_search.py
+++ b/tests/test_async_vectorstore_search.py
@@ -151,13 +151,14 @@ class TestVectorStoreSearch:
         red_uri = str(uuid.uuid4()).replace("-", "_") + "test_image_red.jpg"
         green_uri = str(uuid.uuid4()).replace("-", "_") + "test_image_green.jpg"
         blue_uri = str(uuid.uuid4()).replace("-", "_") + "test_image_blue.jpg"
+        gcs_uri = "gs://github-repo/img/vision/google-cloud-next.jpeg"
         image = Image.new("RGB", (100, 100), color="red")
         image.save(red_uri)
         image = Image.new("RGB", (100, 100), color="green")
         image.save(green_uri)
         image = Image.new("RGB", (100, 100), color="blue")
         image.save(blue_uri)
-        image_uris = [red_uri, green_uri, blue_uri]
+        image_uris = [red_uri, green_uri, blue_uri, gcs_uri]
         yield image_uris
         for uri in image_uris:
             os.remove(uri)
@@ -186,6 +187,9 @@ class TestVectorStoreSearch:
         results = await image_vs.asimilarity_search_image(image_uris[0], k=1)
         assert len(results) == 1
         assert results[0].metadata["image_uri"] == image_uris[0]
+        results = await image_vs.asimilarity_search_image(image_uris[3], k=1)
+        assert len(results) == 1
+        assert results[0].metadata["image_uri"] == image_uris[3]
 
     async def test_asimilarity_search_score(self, vs):
         results = await vs.asimilarity_search_with_score("foo")

--- a/tests/test_vectorstore.py
+++ b/tests/test_vectorstore.py
@@ -198,13 +198,14 @@ class TestVectorStore:
         red_uri = str(uuid.uuid4()).replace("-", "_") + "test_image_red.jpg"
         green_uri = str(uuid.uuid4()).replace("-", "_") + "test_image_green.jpg"
         blue_uri = str(uuid.uuid4()).replace("-", "_") + "test_image_blue.jpg"
+        gcs_uri = "gs://github-repo/img/vision/google-cloud-next.jpeg"
         image = Image.new("RGB", (100, 100), color="red")
         image.save(red_uri)
         image = Image.new("RGB", (100, 100), color="green")
         image.save(green_uri)
         image = Image.new("RGB", (100, 100), color="blue")
         image.save(blue_uri)
-        image_uris = [red_uri, green_uri, blue_uri]
+        image_uris = [red_uri, green_uri, blue_uri, gcs_uri]
         yield image_uris
         for uri in image_uris:
             os.remove(uri)
@@ -347,7 +348,7 @@ class TestVectorStore:
         ]
         await vs.aadd_images(image_uris, metadatas, ids)
         results = await afetch(engine_sync, f'SELECT * FROM "{IMAGE_TABLE}"')
-        assert len(results) == 3
+        assert len(results) == 4
         assert results[0]["image_id"] == "0"
         assert results[0]["source"] == "google.com"
         await aexecute(engine_sync, f'TRUNCATE TABLE "{IMAGE_TABLE}"')

--- a/tests/test_vectorstore.py
+++ b/tests/test_vectorstore.py
@@ -208,7 +208,10 @@ class TestVectorStore:
         image_uris = [red_uri, green_uri, blue_uri, gcs_uri]
         yield image_uris
         for uri in image_uris:
-            os.remove(uri)
+            try:
+                os.remove(uri)
+            except FileNotFoundError:
+                pass
 
     async def test_init_with_constructor(self, engine):
         with pytest.raises(Exception):

--- a/tests/test_vectorstore_search.py
+++ b/tests/test_vectorstore_search.py
@@ -179,7 +179,10 @@ class TestVectorStoreSearch:
         image_uris = [red_uri, green_uri, blue_uri, gcs_uri]
         yield image_uris
         for uri in image_uris:
-            os.remove(uri)
+            try:
+                os.remove(uri)
+            except FileNotFoundError:
+                pass
 
     @pytest_asyncio.fixture(scope="class")
     async def image_vs(self, engine, image_uris):

--- a/tests/test_vectorstore_search.py
+++ b/tests/test_vectorstore_search.py
@@ -169,13 +169,14 @@ class TestVectorStoreSearch:
         red_uri = str(uuid.uuid4()).replace("-", "_") + "test_image_red.jpg"
         green_uri = str(uuid.uuid4()).replace("-", "_") + "test_image_green.jpg"
         blue_uri = str(uuid.uuid4()).replace("-", "_") + "test_image_blue.jpg"
+        gcs_uri = "gs://github-repo/img/vision/google-cloud-next.jpeg"
         image = Image.new("RGB", (100, 100), color="red")
         image.save(red_uri)
         image = Image.new("RGB", (100, 100), color="green")
         image.save(green_uri)
         image = Image.new("RGB", (100, 100), color="blue")
         image.save(blue_uri)
-        image_uris = [red_uri, green_uri, blue_uri]
+        image_uris = [red_uri, green_uri, blue_uri, gcs_uri]
         yield image_uris
         for uri in image_uris:
             os.remove(uri)
@@ -204,6 +205,9 @@ class TestVectorStoreSearch:
         results = await image_vs.asimilarity_search_image(image_uris[0], k=1)
         assert len(results) == 1
         assert results[0].metadata["image_uri"] == image_uris[0]
+        results = await image_vs.asimilarity_search_image(image_uris[3], k=1)
+        assert len(results) == 1
+        assert results[0].metadata["image_uri"] == image_uris[3]
 
     async def test_asimilarity_search_score(self, vs):
         results = await vs.asimilarity_search_with_score("foo")


### PR DESCRIPTION
1. Add GCS and web URI support for image embedding (for VertexAIEmbedding use only. Other embedding models mostly only support local URI).
2. Update embedding service's image embedding API call to check for both `embed_images()` and `embed_image()` methods to accommodate different interfaces.