### PR TITLE
chore: pin pydantic version to avoid a reasoning engine failure

### DIFF
--- a/samples/langchain_on_vertexai/requirements.txt
+++ b/samples/langchain_on_vertexai/requirements.txt
@@ -3,3 +3,6 @@ langchain-google-alloydb-pg==0.7.0
 langchain-google-vertexai==2.0.7
 google-cloud-resource-manager==1.13.0
 langchain-community==0.3.7
+# Required to fix: "PydanticUndefinedAnnotation: name 'SafetySetting' is not defined"
+# Todo: remove after upstream issue is fixed: https://github.com/langchain-ai/langchain/issues/28271
+pydantic==2.9.0


### PR DESCRIPTION
Reasoning engine is failing in https://github.com/googleapis/langchain-google-alloydb-pg-python/pull/283 hence this PR is needed to fix the tests.

Without this change, the tests in reasoning engine fail: [test log](https://pantheon.corp.google.com/cloud-build/builds;region=global/fcf59fc2-f3bd-40f8-b40e-226b9323f22f;step=2?e=13802955&inv=1&invt=Abjoqw&mods=logs_tg_staging&project=langchain-alloydb-testing) saying:

`NameError: name 'SafetySetting' is not defined. Did you mean: 'SafetySettingsType'?`

which is caused due to below exception:
```
  File "/builder/home/.local/lib/python3.11/site-packages/pydantic/_internal/_generate_schema.py", line 1229, in _common_field_schema
    raise PydanticUndefinedAnnotation.from_name_error(e) from e
pydantic.errors.PydanticUndefinedAnnotation: name 'SafetySetting' is not defined
```

With this change, the tests in reasoning engine pass: [test log](https://pantheon.corp.google.com/cloud-build/builds/4607c565-173c-489e-ad78-893b3c58c017?project=langchain-alloydb-testing&e=13802955&mods=logs_tg_staging&invt=Abjoqw&inv=1).

Relevant issue in langchain repo: https://github.com/langchain-ai/langchain/issues/28271