### PR TITLE
feat: add engine_args argument to engine creation functions

### DIFF
--- a/src/langchain_google_alloydb_pg/engine.py
+++ b/src/langchain_google_alloydb_pg/engine.py
@@ -249,7 +249,7 @@ class AlloyDBEngine:
             engine_args (Mapping): Additional arguments that are passed directly to
                 :func:`~sqlalchemy.ext.asyncio.mymodule.MyClass.create_async_engine`. This can be
                 used to specify additional parameters to the underlying pool during it's creation.
-                
+
         Raises:
             ValueError: Raises error if only one of 'user' or 'password' is specified.
 

--- a/src/langchain_google_alloydb_pg/engine.py
+++ b/src/langchain_google_alloydb_pg/engine.py
@@ -249,6 +249,7 @@ class AlloyDBEngine:
             engine_args (Mapping): Additional arguments that are passed directly to
                 :func:`~sqlalchemy.ext.asyncio.mymodule.MyClass.create_async_engine`. This can be
                 used to specify additional parameters to the underlying pool during it's creation.
+                
         Raises:
             ValueError: Raises error if only one of 'user' or 'password' is specified.
 

--- a/src/langchain_google_alloydb_pg/engine.py
+++ b/src/langchain_google_alloydb_pg/engine.py
@@ -195,7 +195,9 @@ class AlloyDBEngine:
             password (Optional[str]): Cloud AlloyDB user password. Defaults to None.
             ip_type (Union[str, IPTypes], optional): IP address type. Defaults to IPTypes.PUBLIC.
             iam_account_email (Optional[str], optional): IAM service account email. Defaults to None.
-            engine_args (Mapping): Additional arguments that are passed directly to  :func:`~sqlalchemy.ext.asyncio.mymodule.MyClass.create_async_engine`. This can be used
+            engine_args (Mapping): Additional arguments that are passed directly to
+                :func:`~sqlalchemy.ext.asyncio.mymodule.MyClass.create_async_engine`. This can be
+                used to specify additional parameters to the underlying pool during it's creation.
 
         Returns:
             AlloyDBEngine: A newly created AlloyDBEngine instance.
@@ -244,8 +246,9 @@ class AlloyDBEngine:
             loop (Optional[asyncio.AbstractEventLoop]): Async event loop used to create the engine.
             thread (Optional[Thread]): Thread used to create the engine async.
             iam_account_email (Optional[str]): IAM service account email.
-            engine_args (Mapping): Additional arguments that are passed directly to  :func:`~sqlalchemy.ext.asyncio.mymodule.MyClass.create_async_engine`. This can be used
-
+            engine_args (Mapping): Additional arguments that are passed directly to
+                :func:`~sqlalchemy.ext.asyncio.mymodule.MyClass.create_async_engine`. This can be
+                used to specify additional parameters to the underlying pool during it's creation.
         Raises:
             ValueError: Raises error if only one of 'user' or 'password' is specified.
 
@@ -327,8 +330,9 @@ class AlloyDBEngine:
             password (Optional[str], optional): Cloud AlloyDB user password. Defaults to None.
             ip_type (Union[str, IPTypes], optional): IP address type. Defaults to IPTypes.PUBLIC.
             iam_account_email (Optional[str], optional): IAM service account email. Defaults to None.
-            engine_args (Mapping): Additional arguments that are passed directly to  :func:`~sqlalchemy.ext.asyncio.mymodule.MyClass.create_async_engine`. This can be used
-
+            engine_args (Mapping): Additional arguments that are passed directly to
+                :func:`~sqlalchemy.ext.asyncio.mymodule.MyClass.create_async_engine`. This can be
+                used to specify additional parameters to the underlying pool during it's creation.
 
         Returns:
             AlloyDBEngine: A newly created AlloyDBEngine instance.
@@ -359,7 +363,7 @@ class AlloyDBEngine:
     @classmethod
     def from_engine_args(
         cls,
-        url: str| URL,
+        url: str | URL,
         **kwargs: Any,
     ) -> AlloyDBEngine:
         """Create an AlloyDBEngine instance from arguments

--- a/src/langchain_google_alloydb_pg/engine.py
+++ b/src/langchain_google_alloydb_pg/engine.py
@@ -17,7 +17,7 @@ import asyncio
 from concurrent.futures import Future
 from dataclasses import dataclass
 from threading import Thread
-from typing import TYPE_CHECKING, Any, Awaitable, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Awaitable, Mapping, Optional, TypeVar, Union
 
 import aiohttp
 import google.auth  # type: ignore
@@ -143,6 +143,7 @@ class AlloyDBEngine:
         password: Optional[str] = None,
         ip_type: Union[str, IPTypes] = IPTypes.PUBLIC,
         iam_account_email: Optional[str] = None,
+        engine_args: Mapping = {},
     ) -> Future:
         # Running a loop in a background thread allows us to support
         # async methods from non-async environments
@@ -164,6 +165,7 @@ class AlloyDBEngine:
             loop=cls._default_loop,
             thread=cls._default_thread,
             iam_account_email=iam_account_email,
+            engine_args=engine_args,
         )
         return asyncio.run_coroutine_threadsafe(coro, cls._default_loop)
 
@@ -179,6 +181,7 @@ class AlloyDBEngine:
         password: Optional[str] = None,
         ip_type: Union[str, IPTypes] = IPTypes.PUBLIC,
         iam_account_email: Optional[str] = None,
+        engine_args: Mapping = {},
     ) -> AlloyDBEngine:
         """Create an AlloyDBEngine from an AlloyDB instance.
 
@@ -192,6 +195,7 @@ class AlloyDBEngine:
             password (Optional[str]): Cloud AlloyDB user password. Defaults to None.
             ip_type (Union[str, IPTypes], optional): IP address type. Defaults to IPTypes.PUBLIC.
             iam_account_email (Optional[str], optional): IAM service account email. Defaults to None.
+            engine_args (Mapping): Additional arguments that are passed directly to  :func:`~sqlalchemy.ext.asyncio.mymodule.MyClass.create_async_engine`. This can be used
 
         Returns:
             AlloyDBEngine: A newly created AlloyDBEngine instance.
@@ -206,6 +210,7 @@ class AlloyDBEngine:
             password,
             ip_type,
             iam_account_email=iam_account_email,
+            engine_args=engine_args,
         )
         return future.result()
 
@@ -223,6 +228,7 @@ class AlloyDBEngine:
         loop: Optional[asyncio.AbstractEventLoop] = None,
         thread: Optional[Thread] = None,
         iam_account_email: Optional[str] = None,
+        engine_args: Mapping = {},
     ) -> AlloyDBEngine:
         """Create an AlloyDBEngine from an AlloyDB instance.
 
@@ -238,6 +244,7 @@ class AlloyDBEngine:
             loop (Optional[asyncio.AbstractEventLoop]): Async event loop used to create the engine.
             thread (Optional[Thread]): Thread used to create the engine async.
             iam_account_email (Optional[str]): IAM service account email.
+            engine_args (Mapping): Additional arguments that are passed directly to  :func:`~sqlalchemy.ext.asyncio.mymodule.MyClass.create_async_engine`. This can be used
 
         Raises:
             ValueError: Raises error if only one of 'user' or 'password' is specified.
@@ -290,6 +297,7 @@ class AlloyDBEngine:
         engine = create_async_engine(
             "postgresql+asyncpg://",
             async_creator=getconn,
+            **engine_args,
         )
         return cls(cls.__create_key, engine, loop, thread)
 
@@ -305,6 +313,7 @@ class AlloyDBEngine:
         password: Optional[str] = None,
         ip_type: Union[str, IPTypes] = IPTypes.PUBLIC,
         iam_account_email: Optional[str] = None,
+        engine_args: Mapping = {},
     ) -> AlloyDBEngine:
         """Create an AlloyDBEngine from an AlloyDB instance.
 
@@ -318,6 +327,8 @@ class AlloyDBEngine:
             password (Optional[str], optional): Cloud AlloyDB user password. Defaults to None.
             ip_type (Union[str, IPTypes], optional): IP address type. Defaults to IPTypes.PUBLIC.
             iam_account_email (Optional[str], optional): IAM service account email. Defaults to None.
+            engine_args (Mapping): Additional arguments that are passed directly to  :func:`~sqlalchemy.ext.asyncio.mymodule.MyClass.create_async_engine`. This can be used
+
 
         Returns:
             AlloyDBEngine: A newly created AlloyDBEngine instance.
@@ -332,6 +343,7 @@ class AlloyDBEngine:
             password,
             ip_type,
             iam_account_email=iam_account_email,
+            engine_args=engine_args,
         )
         return await asyncio.wrap_future(future)
 
@@ -347,7 +359,7 @@ class AlloyDBEngine:
     @classmethod
     def from_engine_args(
         cls,
-        url: Union[str | URL],
+        url: str| URL,
         **kwargs: Any,
     ) -> AlloyDBEngine:
         """Create an AlloyDBEngine instance from arguments

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -115,6 +115,11 @@ class TestEngineAsync:
             instance=db_instance,
             region=db_region,
             database=db_name,
+            engine_args={
+                # add some connection args to validate engine_args works correctly
+                "pool_size": 3,
+                "max_overflow": 2,
+            },
         )
         yield engine
         await aexecute(engine, f'DROP TABLE "{CUSTOM_TABLE}"')
@@ -129,6 +134,9 @@ class TestEngineAsync:
         embedding = await embeddings_service.aembed_query(content)
         stmt = f"INSERT INTO {DEFAULT_TABLE} (langchain_id, content, embedding) VALUES ('{id}', '{content}','{embedding}');"
         await aexecute(engine, stmt)
+
+    async def test_engine_args(self, engine):
+        assert engine.size() == 3
 
     async def test_init_table_custom(self, engine):
         await engine.ainit_vectorstore_table(

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -55,7 +55,7 @@ async def aexecute(
     query: str,
 ) -> None:
     async def run(engine, query):
-        async with engine._pool.pool().connect() as conn:
+        async with engine._pool.connect() as conn:
             await conn.execute(text(query))
             await conn.commit()
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -136,7 +136,7 @@ class TestEngineAsync:
         await aexecute(engine, stmt)
 
     async def test_engine_args(self, engine):
-        assert engine.size() == 3
+        assert engine._pool.QueuePool.size() == 3
 
     async def test_init_table_custom(self, engine):
         await engine.ainit_vectorstore_table(

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -136,7 +136,7 @@ class TestEngineAsync:
         await aexecute(engine, stmt)
 
     async def test_engine_args(self, engine):
-        assert engine._pool.QueuePool.size() == 3
+        assert engine._pool.pool_size() == 3
 
     async def test_init_table_custom(self, engine):
         await engine.ainit_vectorstore_table(

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -55,7 +55,7 @@ async def aexecute(
     query: str,
 ) -> None:
     async def run(engine, query):
-        async with engine._pool.connect() as conn:
+        async with engine._pool.pool().connect() as conn:
             await conn.execute(text(query))
             await conn.commit()
 
@@ -136,7 +136,7 @@ class TestEngineAsync:
         await aexecute(engine, stmt)
 
     async def test_engine_args(self, engine):
-        assert engine._pool.size() == 3
+        assert "Pool size: 3" in engine._pool.pool.status()
 
     async def test_init_table_custom(self, engine):
         await engine.ainit_vectorstore_table(

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -136,7 +136,7 @@ class TestEngineAsync:
         await aexecute(engine, stmt)
 
     async def test_engine_args(self, engine):
-        assert engine._pool.pool_size() == 3
+        assert engine._pool.size() == 3
 
     async def test_init_table_custom(self, engine):
         await engine.ainit_vectorstore_table(


### PR DESCRIPTION
Adds an "engine_args" argument to engine creation functions that can be used to specify additional parameters to the underlying pool creation.