### PR TITLE
chore: add drop index statements to avoid conflict

### DIFF
--- a/tests/test_async_vectorstore_index.py
+++ b/tests/test_async_vectorstore_index.py
@@ -113,6 +113,7 @@ class TestIndex:
         index = HNSWIndex()
         await vs.aapply_vector_index(index)
         assert await vs.is_valid_index(DEFAULT_INDEX_NAME)
+        await vs.adrop_vector_index()
 
     async def test_areindex(self, vs):
         if not await vs.is_valid_index(DEFAULT_INDEX_NAME):
@@ -121,6 +122,7 @@ class TestIndex:
         await vs.areindex()
         await vs.areindex(DEFAULT_INDEX_NAME)
         assert await vs.is_valid_index(DEFAULT_INDEX_NAME)
+        await vs.adrop_vector_index(DEFAULT_INDEX_NAME)
 
     async def test_dropindex(self, vs):
         await vs.adrop_vector_index()
@@ -138,6 +140,7 @@ class TestIndex:
         await vs.aapply_vector_index(index)
         assert await vs.is_valid_index("secondindex")
         await vs.adrop_vector_index("secondindex")
+        await vs.adrop_vector_index()
 
     async def test_is_valid_index(self, vs):
         is_valid = await vs.is_valid_index("invalid_index")

--- a/tests/test_vectorstore_index.py
+++ b/tests/test_vectorstore_index.py
@@ -126,6 +126,7 @@ class TestIndex:
         index = HNSWIndex()
         vs.apply_vector_index(index)
         assert vs.is_valid_index(DEFAULT_INDEX_NAME)
+        vs.drop_vector_index()
 
     async def test_areindex(self, vs):
         if not vs.is_valid_index(DEFAULT_INDEX_NAME):
@@ -134,6 +135,7 @@ class TestIndex:
         vs.reindex()
         vs.reindex(DEFAULT_INDEX_NAME)
         assert vs.is_valid_index(DEFAULT_INDEX_NAME)
+        vs.drop_vector_index(DEFAULT_INDEX_NAME)
 
     async def test_dropindex(self, vs):
         vs.drop_vector_index()
@@ -151,6 +153,7 @@ class TestIndex:
         vs.apply_vector_index(index)
         assert vs.is_valid_index("secondindex")
         vs.drop_vector_index("secondindex")
+        vs.drop_vector_index()
 
     async def test_is_valid_index(self, vs):
         is_valid = vs.is_valid_index("invalid_index")
@@ -256,6 +259,7 @@ class TestAsyncIndex:
         await vs.areindex()
         await vs.areindex(DEFAULT_INDEX_NAME_ASYNC)
         assert await vs.ais_valid_index(DEFAULT_INDEX_NAME_ASYNC)
+        await vs.adrop_vector_index(DEFAULT_INDEX_NAME_ASYNC)
 
     async def test_dropindex(self, vs):
         await vs.adrop_vector_index()


### PR DESCRIPTION
Adding delete index statements to avoid `DuplicateTableError: Index already exists` errors.

Adding these as part of auditing the other repos across LC & LI, for alloy db & Cloud sql