### PR TITLE
chore: fix weaviate snippets

### DIFF
--- a/samples/migrations/migrate_chromadb_vectorstore_to_alloydb.py
+++ b/samples/migrations/migrate_chromadb_vectorstore_to_alloydb.py
@@ -23,6 +23,7 @@ in batches and uploads to an AlloyDBVectorStore.
 """
 
 # TODO(dev): Replace the values below
+CHROMADB_PATH = "./chroma_langchain_db"
 CHROMADB_COLLECTION_NAME = "example_collection"
 PROJECT_ID = "my-project-id"
 REGION = "us-central1"
@@ -33,7 +34,6 @@ DB_USER = "postgres"
 DB_PWD = "secret-password"
 
 # TODO(developer): Optional, change the values below.
-CHROMADB_PATH = "./chromadb_data"
 VECTOR_SIZE = 768
 CHROMADB_BATCH_SIZE = 10
 ALLOYDB_TABLE_NAME = "alloydb_table"

--- a/samples/migrations/migrate_milvus_vectorstore_to_alloydb.py
+++ b/samples/migrations/migrate_milvus_vectorstore_to_alloydb.py
@@ -23,6 +23,8 @@ in batches and uploads to an AlloyDBVectorStore.
 """
 
 # TODO(dev): Replace the values below
+MILVUS_URI = "./milvus_example.db"
+MILVUS_COLLECTION_NAME = "langchain_example"
 PROJECT_ID = "my-project-id"
 REGION = "us-central1"
 CLUSTER = "my-cluster"
@@ -32,8 +34,6 @@ DB_USER = "postgres"
 DB_PWD = "secret-password"
 
 # TODO(developer): Optional, change the values below.
-MILVUS_URI = "./milvus_data"
-MILVUS_COLLECTION_NAME = "test_milvus"
 VECTOR_SIZE = 768
 MILVUS_BATCH_SIZE = 10
 ALLOYDB_TABLE_NAME = "alloydb_table"

--- a/samples/migrations/migrate_qdrant_vectorstore_to_alloydb.py
+++ b/samples/migrations/migrate_qdrant_vectorstore_to_alloydb.py
@@ -23,6 +23,8 @@ in batches and uploads to an AlloyDBVectorStore.
 """
 
 # TODO(dev): Replace the values below
+QDRANT_PATH = "/tmp/langchain_qdrant"
+QDRANT_COLLECTION_NAME = "demo_collection"
 PROJECT_ID = "my-project-id"
 REGION = "us-central1"
 CLUSTER = "my-cluster"
@@ -31,9 +33,7 @@ DB_NAME = "my-db"
 DB_USER = "postgres"
 DB_PWD = "secret-password"
 
-# TODO(developer): Change the values below.
-QDRANT_COLLECTION_NAME = "test_qdrant"
-QDRANT_PATH = "./qdrant_data"
+# TODO(developer): Optional, change the values below.
 VECTOR_SIZE = 768
 QDRANT_BATCH_SIZE = 10
 ALLOYDB_TABLE_NAME = "alloydb_table"

--- a/samples/migrations/migrate_weaviate_vectorstore_to_alloydb.py
+++ b/samples/migrations/migrate_weaviate_vectorstore_to_alloydb.py
@@ -97,6 +97,7 @@ async def main(
     # [START weaviate_get_client]
     import weaviate
 
+    # For a locally running weaviate instance, use `weaviate.connect_to_local()`
     weaviate_client = weaviate.connect_to_weaviate_cloud(
         cluster_url=weaviate_cluster_url,
         auth_credentials=weaviate.auth.AuthApiKey(weaviate_api_key),

--- a/samples/migrations/migrate_weaviate_vectorstore_to_alloydb.py
+++ b/samples/migrations/migrate_weaviate_vectorstore_to_alloydb.py
@@ -25,7 +25,7 @@ in batches and uploads to an AlloyDBVectorStore.
 # TODO(dev): Replace the values below
 WEAVIATE_API_KEY = "my-wv-api-key"
 WEAVIATE_CLUSTER_URL = "my-wv-cluster-url"
-WEAVIATE_COLLECTION_NAME = "test_weaviate_collection"
+WEAVIATE_COLLECTION_NAME = "example_collection"
 PROJECT_ID = "my-project-id"
 REGION = "us-central1"
 CLUSTER = "my-cluster"

--- a/samples/migrations/migrate_weaviate_vectorstore_to_alloydb.py
+++ b/samples/migrations/migrate_weaviate_vectorstore_to_alloydb.py
@@ -25,6 +25,7 @@ in batches and uploads to an AlloyDBVectorStore.
 # TODO(dev): Replace the values below
 WEAVIATE_API_KEY = "my-wv-api-key"
 WEAVIATE_CLUSTER_URL = "my-wv-cluster-url"
+WEAVIATE_COLLECTION_NAME = "test_weaviate_collection"
 PROJECT_ID = "my-project-id"
 REGION = "us-central1"
 CLUSTER = "my-cluster"
@@ -34,7 +35,6 @@ DB_USER = "postgres"
 DB_PWD = "secret-password"
 
 # TODO(developer): Optional, change the values below.
-WEAVIATE_COLLECTION_NAME = "test_weaviate_collection"
 WEAVIATE_TEXT_KEY = "text"
 VECTOR_SIZE = 768
 WEAVIATE_BATCH_SIZE = 10

--- a/samples/migrations/migrate_weaviate_vectorstore_to_alloydb.py
+++ b/samples/migrations/migrate_weaviate_vectorstore_to_alloydb.py
@@ -60,7 +60,7 @@ def get_data_batch(
         ids.append(str(item.uuid))
         content.append(item.properties["text"])
         embeddings.append(item.vector["default"])
-        del item.properties["text"]
+        del item.properties["text"]  # type: ignore
         metadatas.append(item.properties)
 
         if len(ids) >= weaviate_batch_size:

--- a/samples/migrations/migrate_weaviate_vectorstore_to_alloydb.py
+++ b/samples/migrations/migrate_weaviate_vectorstore_to_alloydb.py
@@ -35,6 +35,7 @@ DB_PWD = "secret-password"
 
 # TODO(developer): Optional, change the values below.
 WEAVIATE_COLLECTION_NAME = "test_weaviate_collection"
+WEAVIATE_TEXT_KEY = "text"
 VECTOR_SIZE = 768
 WEAVIATE_BATCH_SIZE = 10
 ALLOYDB_TABLE_NAME = "alloydb_table"
@@ -46,6 +47,7 @@ from weaviate import WeaviateClient
 def get_data_batch(
     weaviate_client: WeaviateClient,
     weaviate_collection_name: str = WEAVIATE_COLLECTION_NAME,
+    weaviate_text_key: str = WEAVIATE_TEXT_KEY,
     weaviate_batch_size: int = WEAVIATE_BATCH_SIZE,
 ) -> Iterator[tuple[list[str], list[Any], list[list[float]], list[Any]]]:
     # [START weaviate_get_data_batch]
@@ -58,9 +60,9 @@ def get_data_batch(
 
     for item in weaviate_collection.iterator(include_vector=True):
         ids.append(str(item.uuid))
-        content.append(item.properties["text"])
+        content.append(item.properties[weaviate_text_key])
         embeddings.append(item.vector["default"])
-        del item.properties["text"]  # type: ignore
+        del item.properties[weaviate_text_key]  # type: ignore
         metadatas.append(item.properties)
 
         if len(ids) >= weaviate_batch_size:
@@ -78,6 +80,7 @@ def get_data_batch(
 async def main(
     weaviate_api_key: str = WEAVIATE_API_KEY,
     weaviate_collection_name: str = WEAVIATE_COLLECTION_NAME,
+    weaviate_text_key: str = WEAVIATE_TEXT_KEY,
     weaviate_cluster_url: str = WEAVIATE_CLUSTER_URL,
     vector_size: int = VECTOR_SIZE,
     weaviate_batch_size: int = WEAVIATE_BATCH_SIZE,
@@ -97,7 +100,6 @@ async def main(
     weaviate_client = weaviate.connect_to_weaviate_cloud(
         cluster_url=weaviate_cluster_url,
         auth_credentials=weaviate.auth.AuthApiKey(weaviate_api_key),
-        skip_init_checks=True,
     )
     # [END weaviate_get_client]
     print("Weaviate client initiated.")
@@ -149,6 +151,7 @@ async def main(
     data_iterator = get_data_batch(
         weaviate_client=weaviate_client,
         weaviate_collection_name=weaviate_collection_name,
+        weaviate_text_key=weaviate_text_key,
         weaviate_batch_size=weaviate_batch_size,
     )
     # [START weaviate_vectorstore_alloydb_migration_insert_data_batch]

--- a/samples/migrations/requirements.txt
+++ b/samples/migrations/requirements.txt
@@ -2,10 +2,10 @@ grpcio-tools==1.67.1
 langchain-chroma==0.2.0
 langchain-core==0.3.31
 langchain-google-alloydb-pg==0.9.1
-langchain-google-vertexai==2.0.11
 langchain-milvus==0.1.8
 langchain-pinecone==0.2.0
 langchain-qdrant==0.2.0
+langchain-weaviate==0.0.3
 pinecone-client==5.0.1
 protobuf==5.29.1
 pymilvus==2.5.3

--- a/samples/migrations/test_milvus_migration.py
+++ b/samples/migrations/test_milvus_migration.py
@@ -20,7 +20,7 @@ import pytest
 import pytest_asyncio
 from langchain_core.documents import Document
 from langchain_core.embeddings import FakeEmbeddings
-from langchain_milvus import Milvus
+from langchain_milvus import Milvus  # type: ignore
 from migrate_milvus_vectorstore_to_alloydb import main
 from sqlalchemy import text
 from sqlalchemy.engine.row import RowMapping

--- a/samples/migrations/test_pinecone_migration.py
+++ b/samples/migrations/test_pinecone_migration.py
@@ -20,7 +20,7 @@ from typing import Sequence
 import pytest
 import pytest_asyncio
 from langchain_core.documents import Document
-from langchain_google_vertexai import VertexAIEmbeddings
+from langchain_core.embeddings import FakeEmbeddings
 from langchain_pinecone import PineconeVectorStore  # type: ignore
 from migrate_pinecone_vectorstore_to_alloydb import main
 from pinecone import Pinecone, ServerlessSpec  # type: ignore
@@ -83,9 +83,7 @@ def create_pinecone_index(
     index = client.Index(pinecone_index_name)
     vector_store = PineconeVectorStore(
         index=index,
-        embedding=VertexAIEmbeddings(
-            model_name="textembedding-gecko@003", project=project_id
-        ),
+        embedding=FakeEmbeddings(size=768),
     )
 
     ids = ids = [f"{str(uuid.uuid4())}" for i in range(1000)]

--- a/samples/migrations/test_qdrant_migration.py
+++ b/samples/migrations/test_qdrant_migration.py
@@ -20,7 +20,7 @@ import pytest
 import pytest_asyncio
 from langchain_core.documents import Document
 from langchain_core.embeddings import FakeEmbeddings
-from langchain_qdrant import QdrantVectorStore
+from langchain_qdrant import QdrantVectorStore  # type: ignore
 from migrate_qdrant_vectorstore_to_alloydb import main
 from qdrant_client import QdrantClient
 from qdrant_client.http.models import Distance, VectorParams

--- a/samples/migrations/test_weaviate_migration.py
+++ b/samples/migrations/test_weaviate_migration.py
@@ -70,6 +70,7 @@ async def create_weaviate_index(
         Document(page_content=f"content#{i}", metadata={"idv": f"{i}"})
         for i in range(1000)
     ]
+    # For a locally running weaviate instance, use `weaviate.connect_to_local()`
     with weaviate.connect_to_weaviate_cloud(
         cluster_url=weaviate_cluster_url,
         auth_credentials=Auth.api_key(weaviate_api_key),

--- a/samples/migrations/test_weaviate_migration.py
+++ b/samples/migrations/test_weaviate_migration.py
@@ -18,9 +18,14 @@ from typing import Sequence
 
 import pytest
 import pytest_asyncio
+import weaviate
+from langchain_core.documents import Document
+from langchain_core.embeddings import FakeEmbeddings
+from langchain_weaviate.vectorstores import WeaviateVectorStore  # type: ignore
 from migrate_weaviate_vectorstore_to_alloydb import main
 from sqlalchemy import text
 from sqlalchemy.engine.row import RowMapping
+from weaviate.auth import Auth
 
 from langchain_google_alloydb_pg import AlloyDBEngine
 
@@ -55,6 +60,34 @@ async def afetch(engine: AlloyDBEngine, query: str) -> Sequence[RowMapping]:
         return result_fetch
 
     return await engine._run_as_async(run(engine, query))
+
+
+async def create_weaviate_index(
+    weaviate_api_key: str, weaviate_cluster_url: str, weaviate_collection_name: str
+) -> None:
+    uuids = [f"{str(uuid.uuid4())}" for i in range(1000)]
+    documents = [
+        Document(page_content=f"content#{i}", metadata={"idv": f"{i}"})
+        for i in range(1000)
+    ]
+    with weaviate.connect_to_weaviate_cloud(
+        cluster_url=weaviate_cluster_url,
+        auth_credentials=Auth.api_key(weaviate_api_key),
+        skip_init_checks=True,
+    ) as weaviate_client:
+        # delete collection if exists
+        try:
+            weaviate_client.collections.delete(weaviate_collection_name)
+        except Exception:
+            pass
+
+        db = WeaviateVectorStore.from_documents(
+            documents=documents,
+            ids=uuids,
+            embedding=FakeEmbeddings(size=768),
+            client=weaviate_client,
+            index_name=weaviate_collection_name,
+        )
 
 
 @pytest.mark.asyncio(loop_scope="class")
@@ -96,10 +129,6 @@ class TestMigrations:
         return get_env_var("WEAVIATE_URL", "Cluster URL for weaviate instance")
 
     @pytest.fixture(scope="module")
-    def embedding_api_key(self) -> str:
-        return get_env_var("EMBEDDING_API_KEY", "API key for embedding service")
-
-    @pytest.fixture(scope="module")
     def weaviate_collection_name(self) -> str:
         return get_env_var(
             "WEAVIATE_COLLECTION_NAME", "collection name for weaviate instance"
@@ -136,7 +165,7 @@ class TestMigrations:
         capsys,
         weaviate_api_key,
         weaviate_collection_name,
-        embedding_api_key,
+        weaviate_cluster_url,
         db_project,
         db_region,
         db_cluster,
@@ -145,10 +174,14 @@ class TestMigrations:
         db_user,
         db_password,
     ):
+        await create_weaviate_index(
+            weaviate_api_key, weaviate_cluster_url, weaviate_collection_name
+        )
+
         await main(
             weaviate_api_key=weaviate_api_key,
             weaviate_collection_name=weaviate_collection_name,
-            embedding_api_key=embedding_api_key,
+            weaviate_cluster_url=weaviate_cluster_url,
             vector_size=768,
             weaviate_batch_size=50,
             project_id=db_project,
@@ -165,10 +198,12 @@ class TestMigrations:
 
         # Assert on the script's output
         assert "Error" not in err  # Check for errors
-        assert "Weaviate collection reference initiated" in out
+        assert "Weaviate client initiated" in out
         assert "Langchain AlloyDB client initiated" in out
         assert "Langchain Fake Embeddings service initiated." in out
         assert "Langchain AlloyDB vectorstore table created" in out
         assert "Langchain AlloyDBVectorStore initialized" in out
         assert "Weaviate client fetched all data from collection." in out
         assert "Migration completed, inserted all the batches of data to AlloyDB" in out
+        results = await afetch(engine, f'SELECT * FROM "{DEFAULT_TABLE}"')
+        assert len(results) == 1000

--- a/samples/migrations/test_weaviate_migration.py
+++ b/samples/migrations/test_weaviate_migration.py
@@ -73,7 +73,6 @@ async def create_weaviate_index(
     with weaviate.connect_to_weaviate_cloud(
         cluster_url=weaviate_cluster_url,
         auth_credentials=Auth.api_key(weaviate_api_key),
-        skip_init_checks=True,
     ) as weaviate_client:
         # delete collection if exists
         try:
@@ -181,6 +180,7 @@ class TestMigrations:
         await main(
             weaviate_api_key=weaviate_api_key,
             weaviate_collection_name=weaviate_collection_name,
+            weaviate_text_key="text",
             weaviate_cluster_url=weaviate_cluster_url,
             vector_size=768,
             weaviate_batch_size=50,


### PR DESCRIPTION

#### Test Log:



<details>

<summary>PyTest log</summary>

###### Log for pytest command
`cd samples/migrations`

```
(venv311) (base) ➜  migrations git:(code-snippets-weaviate) ✗ venv311/bin/pytest -v test_weaviate_migration.py
/usr/local/google/home/vishwarajanand/github/langchain-google-alloydb-pg-python/samples/migrations/venv311/lib/python3.11/site-packages/pytest_asyncio/plugin.py:207: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
================================================================== test session starts ===================================================================
platform linux -- Python 3.11.9, pytest-8.3.4, pluggy-1.5.0 -- /usr/local/google/home/vishwarajanand/github/langchain-google-alloydb-pg-python/samples/migrations/venv311/bin/python
cachedir: .pytest_cache
rootdir: /usr/local/google/home/vishwarajanand/github/langchain-google-alloydb-pg-python
configfile: pyproject.toml
plugins: anyio-4.8.0, asyncio-0.25.2, langsmith-0.3.1
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=None
collected 1 item                                                                                                                                         

test_weaviate_migration.py::TestMigrations::test_weaviate PASSED                                                                                   [100%]

============================================================== 1 passed in 69.14s (0:01:09) ==============================================================
(venv311) (base) ➜  migrations git:(code-snippets-weaviate) ✗ 
```
</details>