### PR TITLE
chore: make alloydb_table as alloydb_table_name in snippets

### DIFF
--- a/samples/migrations/migrate_chromadb_vectorstore_to_alloydb.py
+++ b/samples/migrations/migrate_chromadb_vectorstore_to_alloydb.py
@@ -77,7 +77,7 @@ async def main(
     region: str = REGION,
     cluster: str = CLUSTER,
     instance: str = INSTANCE,
-    alloydb_table: str = ALLOYDB_TABLE_NAME,
+    alloydb_table_name: str = ALLOYDB_TABLE_NAME,
     db_name: str = DB_NAME,
     db_user: str = DB_USER,
     db_pwd: str = DB_PWD,
@@ -120,7 +120,7 @@ async def main(
 
     # [START chromadb_vectorstore_alloydb_migration_create_table]
     await alloydb_engine.ainit_vectorstore_table(
-        table_name=alloydb_table,
+        table_name=alloydb_table_name,
         vector_size=vector_size,
     )
     # [END chromadb_vectorstore_alloydb_migration_create_table]
@@ -132,7 +132,7 @@ async def main(
     vs = await AlloyDBVectorStore.create(
         engine=alloydb_engine,
         embedding_service=embeddings_service,
-        table_name=alloydb_table,
+        table_name=alloydb_table_name,
     )
     # [END chromadb_vectorstore_alloydb_migration_vector_store]
     print("Langchain AlloyDBVectorStore initialized.")

--- a/samples/migrations/migrate_milvus_vectorstore_to_alloydb.py
+++ b/samples/migrations/migrate_milvus_vectorstore_to_alloydb.py
@@ -88,7 +88,7 @@ async def main(
     region: str = REGION,
     cluster: str = CLUSTER,
     instance: str = INSTANCE,
-    alloydb_table: str = ALLOYDB_TABLE_NAME,
+    alloydb_table_name: str = ALLOYDB_TABLE_NAME,
     db_name: str = DB_NAME,
     db_user: str = DB_USER,
     db_pwd: str = DB_PWD,
@@ -125,7 +125,7 @@ async def main(
 
     # [START milvus_vectorstore_alloydb_migration_create_table]
     await alloydb_engine.ainit_vectorstore_table(
-        table_name=alloydb_table,
+        table_name=alloydb_table_name,
         vector_size=vector_size,
     )
     # [END milvus_vectorstore_alloydb_migration_create_table]
@@ -137,7 +137,7 @@ async def main(
     vs = await AlloyDBVectorStore.create(
         engine=alloydb_engine,
         embedding_service=embeddings_service,
-        table_name=alloydb_table,
+        table_name=alloydb_table_name,
     )
     # [END milvus_vectorstore_alloydb_migration_vector_store]
     print("Langchain AlloyDBVectorStore initialized.")

--- a/samples/migrations/migrate_pinecone_vectorstore_to_alloydb.py
+++ b/samples/migrations/migrate_pinecone_vectorstore_to_alloydb.py
@@ -108,7 +108,7 @@ async def main(
     region: str = REGION,
     cluster: str = CLUSTER,
     instance: str = INSTANCE,
-    alloydb_table: str = ALLOYDB_TABLE_NAME,
+    alloydb_table_name: str = ALLOYDB_TABLE_NAME,
     db_name: str = DB_NAME,
     db_user: str = DB_USER,
     db_pwd: str = DB_PWD,
@@ -139,7 +139,7 @@ async def main(
 
     # [START pinecone_vectorstore_alloydb_migration_create_table]
     await alloydb_engine.ainit_vectorstore_table(
-        table_name=alloydb_table,
+        table_name=alloydb_table_name,
         vector_size=vector_size,
     )
     # [END pinecone_vectorstore_alloydb_migration_create_table]
@@ -160,7 +160,7 @@ async def main(
     vector_store = await AlloyDBVectorStore.create(
         engine=alloydb_engine,
         embedding_service=embedding_service,
-        table_name=alloydb_table,
+        table_name=alloydb_table_name,
     )
     # [END pinecone_vectorstore_alloydb_migration_vector_store]
     print("Langchain AlloyDBVectorStore initialized.")

--- a/samples/migrations/migrate_qdrant_vectorstore_to_alloydb.py
+++ b/samples/migrations/migrate_qdrant_vectorstore_to_alloydb.py
@@ -89,7 +89,7 @@ async def main(
     region: str = REGION,
     cluster: str = CLUSTER,
     instance: str = INSTANCE,
-    alloydb_table: str = ALLOYDB_TABLE_NAME,
+    alloydb_table_name: str = ALLOYDB_TABLE_NAME,
     db_name: str = DB_NAME,
     db_user: str = DB_USER,
     db_pwd: str = DB_PWD,
@@ -129,7 +129,7 @@ async def main(
 
     # [START qdrant_vectorstore_alloydb_migration_create_table]
     await alloydb_engine.ainit_vectorstore_table(
-        table_name=alloydb_table,
+        table_name=alloydb_table_name,
         vector_size=vector_size,
     )
     # [END qdrant_vectorstore_alloydb_migration_create_table]
@@ -141,7 +141,7 @@ async def main(
     vs = await AlloyDBVectorStore.create(
         engine=alloydb_engine,
         embedding_service=embeddings_service,
-        table_name=alloydb_table,
+        table_name=alloydb_table_name,
     )
     # [END qdrant_vectorstore_alloydb_migration_vector_store]
     print("Langchain AlloyDBVectorStore initialized.")

--- a/samples/migrations/migrate_weaviate_vectorstore_to_alloydb.py
+++ b/samples/migrations/migrate_weaviate_vectorstore_to_alloydb.py
@@ -88,7 +88,7 @@ async def main(
     region: str = REGION,
     cluster: str = CLUSTER,
     instance: str = INSTANCE,
-    alloydb_table: str = ALLOYDB_TABLE_NAME,
+    alloydb_table_name: str = ALLOYDB_TABLE_NAME,
     db_name: str = DB_NAME,
     db_user: str = DB_USER,
     db_pwd: str = DB_PWD,
@@ -131,7 +131,7 @@ async def main(
 
     # [START weaviate_vectorstore_alloydb_migration_create_table]
     await alloydb_engine.ainit_vectorstore_table(
-        table_name=alloydb_table,
+        table_name=alloydb_table_name,
         vector_size=vector_size,
     )
 
@@ -144,7 +144,7 @@ async def main(
     vs = await AlloyDBVectorStore.create(
         engine=alloydb_engine,
         embedding_service=embeddings_service,
-        table_name=alloydb_table,
+        table_name=alloydb_table_name,
     )
     # [END weaviate_vectorstore_alloydb_migration_vector_store]
     print("Langchain AlloyDBVectorStore initialized.")

--- a/samples/migrations/test_chromadb_migration.py
+++ b/samples/migrations/test_chromadb_migration.py
@@ -165,7 +165,7 @@ class TestMigrations:
             region=db_region,
             cluster=db_cluster,
             instance=db_instance,
-            alloydb_table=DEFAULT_TABLE,
+            alloydb_table_name=DEFAULT_TABLE,
             db_name=db_name,
             db_user=db_user,
             db_pwd=db_password,

--- a/samples/migrations/test_milvus_migration.py
+++ b/samples/migrations/test_milvus_migration.py
@@ -166,7 +166,7 @@ class TestMigrations:
             region=db_region,
             cluster=db_cluster,
             instance=db_instance,
-            alloydb_table=DEFAULT_TABLE,
+            alloydb_table_name=DEFAULT_TABLE,
             db_name=db_name,
             db_user=db_user,
             db_pwd=db_password,

--- a/samples/migrations/test_pinecone_migration.py
+++ b/samples/migrations/test_pinecone_migration.py
@@ -183,7 +183,7 @@ class TestMigrations:
             region=db_region,
             cluster=db_cluster,
             instance=db_instance,
-            alloydb_table=DEFAULT_TABLE,
+            alloydb_table_name=DEFAULT_TABLE,
             db_name=db_name,
             db_user=db_user,
             db_pwd=db_password,

--- a/samples/migrations/test_qdrant_migration.py
+++ b/samples/migrations/test_qdrant_migration.py
@@ -175,7 +175,7 @@ class TestMigrations:
             region=db_region,
             cluster=db_cluster,
             instance=db_instance,
-            alloydb_table=DEFAULT_TABLE,
+            alloydb_table_name=DEFAULT_TABLE,
             db_name=db_name,
             db_user=db_user,
             db_pwd=db_password,

--- a/samples/migrations/test_weaviate_migration.py
+++ b/samples/migrations/test_weaviate_migration.py
@@ -189,7 +189,7 @@ class TestMigrations:
             region=db_region,
             cluster=db_cluster,
             instance=db_instance,
-            alloydb_table=DEFAULT_TABLE,
+            alloydb_table_name=DEFAULT_TABLE,
             db_name=db_name,
             db_user=db_user,
             db_pwd=db_password,


### PR DESCRIPTION
This will make variable names uniform

<img width="513" alt="Screenshot 2025-01-30 at 14 58 10" src="https://github.com/user-attachments/assets/f58ffaac-4a67-4bf4-a63f-2257191fbad7" />

1. As a CONST variable in top of script (not the snippets) we are using `ALLOYDB_TABLE_NAME`
2. As a variable in the snippets, we are using `alloydb_table`
