### PR TITLE
fix: add write messages to Chat History

### DIFF
--- a/src/langchain_google_alloydb_pg/chat_message_history.py
+++ b/src/langchain_google_alloydb_pg/chat_message_history.py
@@ -107,10 +107,16 @@ class AlloyDBChatMessageHistory(BaseChatMessageHistory):
         history = engine._run_as_sync(coro)
         return cls(cls.__create_key, engine, history)
 
-    @property  # type: ignore[override]
+    @property
     def messages(self) -> list[BaseMessage]:
-        """The abstraction required a property."""
+        """Fetches all messages stored in AlloyDB."""
         return self._engine._run_as_sync(self.__history._aget_messages())
+
+    @messages.setter
+    def messages(self, value: list[BaseMessage]) -> None:
+        """Clear the stored messages and appends a list of messages to the record in AlloyDB."""
+        self.clear()
+        self.add_messages(value)
 
     async def aadd_message(self, message: BaseMessage) -> None:
         """Append the message to the record in AlloyDB"""

--- a/tests/test_chatmessagehistory.py
+++ b/tests/test_chatmessagehistory.py
@@ -175,6 +175,20 @@ async def test_chat_message_history_sync_messages(
 
 
 @pytest.mark.asyncio
+async def test_chat_message_history_set_messages(
+    async_engine: AlloyDBEngine,
+) -> None:
+    history = await AlloyDBChatMessageHistory.create(
+        engine=async_engine, session_id="test", table_name=table_name_async
+    )
+    msg1 = HumanMessage(content="hi!")
+    msg2 = AIMessage(content="bye -_-")
+    # verify setting messages property adds to message history
+    history.messages = [msg1, msg2]
+    assert len(history.messages) == 2
+
+
+@pytest.mark.asyncio
 async def test_chat_table_async(async_engine):
     with pytest.raises(ValueError):
         await AlloyDBChatMessageHistory.create(


### PR DESCRIPTION
Unblocks lint failures in https://github.com/googleapis/langchain-google-alloydb-pg-python/pull/339

[Lint workflow](https://github.com/googleapis/langchain-google-alloydb-pg-python/actions/runs/13153274803/job/36770910902?pr=339) is complaining:
```
src/langchain_google_alloydb_pg/chat_message_history.py:111: error: Cannot override writeable attribute with read-only property  [override]
```

This happens because we are only defining `@property` but not `@messages.setter` since the base class `BaseChatMessageHistory` defines `messages` as a writeable prop.

Adding definition and relevant test.


> Note: this failure is only reported with latest `mypy==1.15.0` version.