### PR TITLE
chore(samples): update samples to fix pinecone data fetch with non-default namespace

### DIFF
--- a/samples/migrations/migrate_pinecone_vectorstore_to_alloydb.py
+++ b/samples/migrations/migrate_pinecone_vectorstore_to_alloydb.py
@@ -77,7 +77,7 @@ def get_data_batch(
     # [START pinecone_get_data_batch]
     # Iterate through the IDs and download their contents
     for ids in id_iterator:
-        all_data = pinecone_index.fetch(ids=ids)
+        all_data = pinecone_index.fetch(ids=ids, namespace=pinecone_namespace)
         ids = []
         embeddings = []
         contents = []


### PR DESCRIPTION
![Screenshot 2025-02-19 at 00 33 58](https://github.com/user-attachments/assets/afcdb34c-08f8-4b5f-88d3-a7d81ba58f40)


Pinecone's `fetch` expects a namespace when a custom namespace is used.