### PR TITLE
fix: Revert "chore(deps): update dependency google-cloud-storage to v3"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 dependencies = [
     "google-cloud-alloydb-connector[asyncpg]>=1.2.0, <2.0.0",
-    "google-cloud-storage>=3.0.0, <3.1.0",
+    "google-cloud-storage>=2.18.2, <3.0.0",
     "langchain-core>=0.2.36, <1.0.0",
     "numpy>=1.24.4, <2.0.0",
     "pgvector>=0.2.5, <1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 dependencies = [
     "google-cloud-alloydb-connector[asyncpg]>=1.2.0, <2.0.0",
-    "google-cloud-storage>=2.18.2, <3.0.0",
+    "google-cloud-storage>=2.18.2, <4.0.0",
     "langchain-core>=0.2.36, <1.0.0",
     "numpy>=1.24.4, <2.0.0",
     "pgvector>=0.2.5, <1.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 google-cloud-alloydb-connector[asyncpg]==1.7.0
-google-cloud-storage>=2.18.2
+google-cloud-storage==2.18.2
 langchain-core==0.3.34
 numpy==1.26.4
 pgvector==0.3.6


### PR DESCRIPTION
Reverts googleapis/langchain-google-alloydb-pg-python#334

We can continue to support the larger range for the GCS dependency and test against the newest versions via requirements.txt.