### PR TITLE
chore: support ids in Documents and update insert SQL query to upsert

### DIFF
--- a/src/langchain_google_alloydb_pg/async_vectorstore.py
+++ b/src/langchain_google_alloydb_pg/async_vectorstore.py
@@ -238,6 +238,7 @@ class AsyncAlloyDBVectorStore(VectorStore):
         if not ids:
             ids = [str(uuid.uuid4()) for _ in texts]
         else:
+            # This is done to fill in any missing ids
             ids = [id if id is not None else str(uuid.uuid4()) for id in ids]
         if not metadatas:
             metadatas = [{} for _ in texts]

--- a/src/langchain_google_alloydb_pg/async_vectorstore.py
+++ b/src/langchain_google_alloydb_pg/async_vectorstore.py
@@ -237,6 +237,8 @@ class AsyncAlloyDBVectorStore(VectorStore):
         """
         if not ids:
             ids = [str(uuid.uuid4()) for _ in texts]
+        else:
+            ids = [id if id is not None else str(uuid.uuid4()) for id in ids]
         if not metadatas:
             metadatas = [{} for _ in texts]
         # Insert embeddings
@@ -274,7 +276,17 @@ class AsyncAlloyDBVectorStore(VectorStore):
             else:
                 values_stmt += ")"
 
-            query = insert_stmt + values_stmt
+            upsert_stmt = f' ON CONFLICT ("{self.id_column}") DO UPDATE SET "{self.content_column}" = EXCLUDED."{self.content_column}", "{self.embedding_column}" = EXCLUDED."{self.embedding_column}"'
+
+            if self.metadata_json_column:
+                upsert_stmt += f', "{self.metadata_json_column}" = EXCLUDED."{self.metadata_json_column}"'
+
+            for column in self.metadata_columns:
+                upsert_stmt += f', "{column}" = EXCLUDED."{column}"'
+
+            upsert_stmt += ";"
+
+            query = insert_stmt + values_stmt + upsert_stmt
             async with self.engine.connect() as conn:
                 await conn.execute(text(query), values)
                 await conn.commit()
@@ -316,6 +328,8 @@ class AsyncAlloyDBVectorStore(VectorStore):
         """
         texts = [doc.page_content for doc in documents]
         metadatas = [doc.metadata for doc in documents]
+        if not ids:
+            ids = [doc.id or doc.metadata.get("id", None) for doc in documents]
         ids = await self.aadd_texts(texts, metadatas=metadatas, ids=ids, **kwargs)
         return ids
 
@@ -705,6 +719,7 @@ class AsyncAlloyDBVectorStore(VectorStore):
                     Document(
                         page_content=row[self.content_column],
                         metadata=metadata,
+                        id=row[self.id_column],
                     ),
                     row["distance"],
                 )
@@ -795,6 +810,7 @@ class AsyncAlloyDBVectorStore(VectorStore):
                     Document(
                         page_content=row[self.content_column],
                         metadata=metadata,
+                        id=row[self.id_column],
                     ),
                     row["distance"],
                 )

--- a/src/langchain_google_alloydb_pg/async_vectorstore.py
+++ b/src/langchain_google_alloydb_pg/async_vectorstore.py
@@ -329,7 +329,7 @@ class AsyncAlloyDBVectorStore(VectorStore):
         texts = [doc.page_content for doc in documents]
         metadatas = [doc.metadata for doc in documents]
         if not ids:
-            ids = [doc.id or doc.metadata.get("id", None) for doc in documents]
+            ids = [doc.id for doc in documents]
         ids = await self.aadd_texts(texts, metadatas=metadatas, ids=ids, **kwargs)
         return ids
 

--- a/tests/test_async_vectorstore_search.py
+++ b/tests/test_async_vectorstore_search.py
@@ -122,7 +122,6 @@ class TestVectorStoreSearch:
             embedding_service=embeddings_service,
             table_name=DEFAULT_TABLE,
         )
-        ids = [str(uuid.uuid4()) for i in range(len(texts))]
         await vs.aadd_documents(docs, ids=ids)
         yield vs
 
@@ -204,18 +203,18 @@ class TestVectorStoreSearch:
     async def test_asimilarity_search(self, vs):
         results = await vs.asimilarity_search("foo", k=1)
         assert len(results) == 1
-        assert results == [Document(page_content="foo")]
+        assert results == [Document(page_content="foo", id=ids[0])]
         results = await vs.asimilarity_search("foo", k=1, filter="content = 'bar'")
-        assert results == [Document(page_content="bar")]
+        assert results == [Document(page_content="bar", id=ids[1])]
 
     async def test_asimilarity_search_scann(self, vs_custom_scann_query_option):
         results = await vs_custom_scann_query_option.asimilarity_search("foo", k=1)
         assert len(results) == 1
-        assert results == [Document(page_content="foo")]
+        assert results == [Document(page_content="foo", id=ids[0])]
         results = await vs_custom_scann_query_option.asimilarity_search(
             "foo", k=1, filter="mycontent = 'bar'"
         )
-        assert results == [Document(page_content="bar")]
+        assert results == [Document(page_content="bar", id=ids[1])]
 
     async def test_asimilarity_search_image(self, image_vs, image_uris):
         results = await image_vs.asimilarity_search_image(image_uris[0], k=1)
@@ -228,16 +227,16 @@ class TestVectorStoreSearch:
     async def test_asimilarity_search_score(self, vs):
         results = await vs.asimilarity_search_with_score("foo")
         assert len(results) == 4
-        assert results[0][0] == Document(page_content="foo")
+        assert results[0][0] == Document(page_content="foo", id=ids[0])
         assert results[0][1] == 0
 
     async def test_asimilarity_search_by_vector(self, vs):
         embedding = embeddings_service.embed_query("foo")
         results = await vs.asimilarity_search_by_vector(embedding)
         assert len(results) == 4
-        assert results[0] == Document(page_content="foo")
+        assert results[0] == Document(page_content="foo", id=ids[0])
         results = await vs.asimilarity_search_with_score_by_vector(embedding)
-        assert results[0][0] == Document(page_content="foo")
+        assert results[0][0] == Document(page_content="foo", id=ids[0])
         assert results[0][1] == 0
 
     async def test_similarity_search_with_relevance_scores_threshold_cosine(self, vs):
@@ -260,7 +259,7 @@ class TestVectorStoreSearch:
             "foo", **score_threshold
         )
         assert len(results) == 1
-        assert results[0][0] == Document(page_content="foo")
+        assert results[0][0] == Document(page_content="foo", id=ids[0])
 
         score_threshold = {"score_threshold": 0.02}
         vs.distance_strategy = DistanceStrategy.EUCLIDEAN
@@ -284,41 +283,41 @@ class TestVectorStoreSearch:
             "foo", **score_threshold
         )
         assert len(results) == 1
-        assert results[0][0] == Document(page_content="foo")
+        assert results[0][0] == Document(page_content="foo", id=ids[0])
 
     async def test_amax_marginal_relevance_search(self, vs):
         results = await vs.amax_marginal_relevance_search("bar")
-        assert results[0] == Document(page_content="bar")
+        assert results[0] == Document(page_content="bar", id=ids[1])
         results = await vs.amax_marginal_relevance_search(
             "bar", filter="content = 'boo'"
         )
-        assert results[0] == Document(page_content="boo")
+        assert results[0] == Document(page_content="boo", id=ids[3])
 
     async def test_amax_marginal_relevance_search_vector(self, vs):
         embedding = embeddings_service.embed_query("bar")
         results = await vs.amax_marginal_relevance_search_by_vector(embedding)
-        assert results[0] == Document(page_content="bar")
+        assert results[0] == Document(page_content="bar", id=ids[1])
 
     async def test_amax_marginal_relevance_search_vector_score(self, vs):
         embedding = embeddings_service.embed_query("bar")
         results = await vs.amax_marginal_relevance_search_with_score_by_vector(
             embedding
         )
-        assert results[0][0] == Document(page_content="bar")
+        assert results[0][0] == Document(page_content="bar", id=ids[1])
 
         results = await vs.amax_marginal_relevance_search_with_score_by_vector(
             embedding, lambda_mult=0.75, fetch_k=10
         )
-        assert results[0][0] == Document(page_content="bar")
+        assert results[0][0] == Document(page_content="bar", id=ids[1])
 
     async def test_similarity_search(self, vs_custom):
         results = await vs_custom.asimilarity_search("foo", k=1)
         assert len(results) == 1
-        assert results == [Document(page_content="foo")]
+        assert results == [Document(page_content="foo", id=ids[0])]
         results = await vs_custom.asimilarity_search(
             "foo", k=1, filter="mycontent = 'bar'"
         )
-        assert results == [Document(page_content="bar")]
+        assert results == [Document(page_content="bar", id=ids[1])]
 
     async def test_similarity_search_image(self, image_vs, image_uris):
         with pytest.raises(NotImplementedError):
@@ -327,39 +326,39 @@ class TestVectorStoreSearch:
     async def test_similarity_search_score(self, vs_custom):
         results = await vs_custom.asimilarity_search_with_score("foo")
         assert len(results) == 4
-        assert results[0][0] == Document(page_content="foo")
+        assert results[0][0] == Document(page_content="foo", id=ids[0])
         assert results[0][1] == 0
 
     async def test_similarity_search_by_vector(self, vs_custom):
         embedding = embeddings_service.embed_query("foo")
         results = await vs_custom.asimilarity_search_by_vector(embedding)
         assert len(results) == 4
-        assert results[0] == Document(page_content="foo")
+        assert results[0] == Document(page_content="foo", id=ids[0])
         results = await vs_custom.asimilarity_search_with_score_by_vector(embedding)
-        assert results[0][0] == Document(page_content="foo")
+        assert results[0][0] == Document(page_content="foo", id=ids[0])
         assert results[0][1] == 0
 
     async def test_max_marginal_relevance_search(self, vs_custom):
         results = await vs_custom.amax_marginal_relevance_search("bar")
-        assert results[0] == Document(page_content="bar")
+        assert results[0] == Document(page_content="bar", id=ids[1])
         results = await vs_custom.amax_marginal_relevance_search(
             "bar", filter="mycontent = 'boo'"
         )
-        assert results[0] == Document(page_content="boo")
+        assert results[0] == Document(page_content="boo", id=ids[3])
 
     async def test_max_marginal_relevance_search_vector(self, vs_custom):
         embedding = embeddings_service.embed_query("bar")
         results = await vs_custom.amax_marginal_relevance_search_by_vector(embedding)
-        assert results[0] == Document(page_content="bar")
+        assert results[0] == Document(page_content="bar", id=ids[1])
 
     async def test_max_marginal_relevance_search_vector_score(self, vs_custom):
         embedding = embeddings_service.embed_query("bar")
         results = await vs_custom.amax_marginal_relevance_search_with_score_by_vector(
             embedding
         )
-        assert results[0][0] == Document(page_content="bar")
+        assert results[0][0] == Document(page_content="bar", id=ids[1])
 
         results = await vs_custom.amax_marginal_relevance_search_with_score_by_vector(
             embedding, lambda_mult=0.75, fetch_k=10
         )
-        assert results[0][0] == Document(page_content="bar")
+        assert results[0][0] == Document(page_content="bar", id=ids[1])

--- a/tests/test_standard_test_suite.py
+++ b/tests/test_standard_test_suite.py
@@ -101,7 +101,7 @@ class TestStandardSuiteSync(VectorStoreIntegrationTests):
         sync_engine.init_vectorstore_table(
             DEFAULT_TABLE_SYNC,
             EMBEDDING_SIZE,
-            id_column=Column(name="langchain_id", data_type="VARCHAR", nullable=False),
+            id_column=Column(name="langchain_id", data_type="INTEGER", nullable=False),
         )
 
         vs = AlloyDBVectorStore.create_sync(
@@ -167,7 +167,7 @@ class TestStandardSuiteAsync(VectorStoreIntegrationTests):
         await async_engine.ainit_vectorstore_table(
             DEFAULT_TABLE,
             EMBEDDING_SIZE,
-            id_column=Column(name="langchain_id", data_type="VARCHAR", nullable=False),
+            id_column=Column(name="langchain_id", data_type="INTEGER", nullable=False),
         )
 
         vs = await AlloyDBVectorStore.create(

--- a/tests/test_standard_test_suite.py
+++ b/tests/test_standard_test_suite.py
@@ -79,7 +79,7 @@ class TestStandardSuiteSync(VectorStoreIntegrationTests):
 
     @pytest_asyncio.fixture(loop_scope="function")
     async def sync_engine(
-        self, db_project, db_region, db_cluster, db_instance, db_name, user, password
+        self, db_project, db_region, db_cluster, db_instance, db_name
     ):
         sync_engine = AlloyDBEngine.from_instance(
             project_id=db_project,
@@ -87,8 +87,6 @@ class TestStandardSuiteSync(VectorStoreIntegrationTests):
             instance=db_instance,
             region=db_region,
             database=db_name,
-            user=user,
-            password=password,
         )
         yield sync_engine
         await aexecute(sync_engine, f'DROP TABLE IF EXISTS "{DEFAULT_TABLE_SYNC}"')
@@ -101,7 +99,7 @@ class TestStandardSuiteSync(VectorStoreIntegrationTests):
         sync_engine.init_vectorstore_table(
             DEFAULT_TABLE_SYNC,
             EMBEDDING_SIZE,
-            id_column=Column(name="langchain_id", data_type="INTEGER", nullable=False),
+            id_column=Column(name="langchain_id", data_type="VARCHAR", nullable=False),
         )
 
         vs = AlloyDBVectorStore.create_sync(
@@ -145,7 +143,7 @@ class TestStandardSuiteAsync(VectorStoreIntegrationTests):
 
     @pytest_asyncio.fixture(loop_scope="function")
     async def async_engine(
-        self, db_project, db_region, db_cluster, db_instance, db_name, user, password
+        self, db_project, db_region, db_cluster, db_instance, db_name
     ):
         async_engine = await AlloyDBEngine.afrom_instance(
             project_id=db_project,
@@ -153,8 +151,6 @@ class TestStandardSuiteAsync(VectorStoreIntegrationTests):
             instance=db_instance,
             region=db_region,
             database=db_name,
-            user=user,
-            password=password,
         )
         yield async_engine
         await aexecute(async_engine, f'DROP TABLE IF EXISTS "{DEFAULT_TABLE}"')
@@ -167,7 +163,7 @@ class TestStandardSuiteAsync(VectorStoreIntegrationTests):
         await async_engine.ainit_vectorstore_table(
             DEFAULT_TABLE,
             EMBEDDING_SIZE,
-            id_column=Column(name="langchain_id", data_type="INTEGER", nullable=False),
+            id_column=Column(name="langchain_id", data_type="VARCHAR", nullable=False),
         )
 
         vs = await AlloyDBVectorStore.create(

--- a/tests/test_vectorstore_embeddings.py
+++ b/tests/test_vectorstore_embeddings.py
@@ -118,7 +118,6 @@ class TestVectorStoreEmbeddings:
             embedding_service=embeddings_service,
             table_name=DEFAULT_TABLE,
         )
-        ids = [str(uuid.uuid4()) for i in range(len(texts))]
         await vs.aadd_documents(docs, ids=ids)
         yield vs
 
@@ -172,23 +171,23 @@ class TestVectorStoreEmbeddings:
     async def test_asimilarity_search(self, vs):
         results = await vs.asimilarity_search("foo", k=1)
         assert len(results) == 1
-        assert results == [Document(page_content="foo")]
+        assert results == [Document(page_content="foo", id=ids[0])]
         results = await vs.asimilarity_search("foo", k=1, filter="content = 'bar'")
-        assert results == [Document(page_content="bar")]
+        assert results == [Document(page_content="bar", id=ids[1])]
 
     async def test_asimilarity_search_score(self, vs):
         results = await vs.asimilarity_search_with_score("foo")
         assert len(results) == 4
-        assert results[0][0] == Document(page_content="foo")
+        assert results[0][0] == Document(page_content="foo", id=ids[0])
         assert results[0][1] == 0
 
     async def test_asimilarity_search_by_vector(self, vs, embeddings_service):
         search_embedding = embeddings_service.embed_query("foo")
         results = await vs.asimilarity_search_by_vector(search_embedding)
         assert len(results) == 4
-        assert results[0] == Document(page_content="foo")
+        assert results[0] == Document(page_content="foo", id=ids[0])
         results = await vs.asimilarity_search_with_score_by_vector(search_embedding)
-        assert results[0][0] == Document(page_content="foo")
+        assert results[0][0] == Document(page_content="foo", id=ids[0])
         assert results[0][1] == 0
 
     async def test_similarity_search_with_relevance_scores_threshold_cosine(self, vs):
@@ -209,7 +208,7 @@ class TestVectorStoreEmbeddings:
             "foo", **score_threshold
         )
         assert len(results) == 1
-        assert results[0][0] == Document(page_content="foo")
+        assert results[0][0] == Document(page_content="foo", id=ids[0])
 
     async def test_similarity_search_with_relevance_scores_threshold_euclidean(
         self, engine, embeddings_service
@@ -226,20 +225,20 @@ class TestVectorStoreEmbeddings:
             "foo", **score_threshold
         )
         assert len(results) == 1
-        assert results[0][0] == Document(page_content="foo")
+        assert results[0][0] == Document(page_content="foo", id=ids[0])
 
     async def test_amax_marginal_relevance_search(self, vs):
         results = await vs.amax_marginal_relevance_search("bar")
-        assert results[0] == Document(page_content="bar")
+        assert results[0] == Document(page_content="bar", id=ids[1])
         results = await vs.amax_marginal_relevance_search(
             "bar", filter="content = 'boo'"
         )
-        assert results[0] == Document(page_content="boo")
+        assert results[0] == Document(page_content="boo", id=ids[3])
 
     async def test_amax_marginal_relevance_search_vector(self, vs, embeddings_service):
         embedding = embeddings_service.embed_query("bar")
         results = await vs.amax_marginal_relevance_search_by_vector(embedding)
-        assert results[0] == Document(page_content="bar")
+        assert results[0] == Document(page_content="bar", id=ids[1])
 
     async def test_amax_marginal_relevance_search_vector_score(
         self, vs, embeddings_service
@@ -248,12 +247,12 @@ class TestVectorStoreEmbeddings:
         results = await vs.amax_marginal_relevance_search_with_score_by_vector(
             embedding
         )
-        assert results[0][0] == Document(page_content="bar")
+        assert results[0][0] == Document(page_content="bar", id=ids[1])
 
         results = await vs.amax_marginal_relevance_search_with_score_by_vector(
             embedding, lambda_mult=0.75, fetch_k=10
         )
-        assert results[0][0] == Document(page_content="bar")
+        assert results[0][0] == Document(page_content="bar", id=ids[1])
 
 
 class TestVectorStoreEmbeddingsSync:
@@ -331,37 +330,37 @@ class TestVectorStoreEmbeddingsSync:
     def test_similarity_search(self, vs_custom):
         results = vs_custom.similarity_search("foo", k=1)
         assert len(results) == 1
-        assert results == [Document(page_content="foo")]
+        assert results == [Document(page_content="foo", id=ids[0])]
         results = vs_custom.similarity_search("foo", k=1, filter="mycontent = 'bar'")
-        assert results == [Document(page_content="bar")]
+        assert results == [Document(page_content="bar", id=ids[1])]
 
     def test_similarity_search_score(self, vs_custom):
         results = vs_custom.similarity_search_with_score("foo")
         assert len(results) == 4
-        assert results[0][0] == Document(page_content="foo")
+        assert results[0][0] == Document(page_content="foo", id=ids[0])
         assert results[0][1] == 0
 
     def test_similarity_search_by_vector(self, vs_custom, embeddings_service):
         embedding = embeddings_service.embed_query("foo")
         results = vs_custom.similarity_search_by_vector(embedding)
         assert len(results) == 4
-        assert results[0] == Document(page_content="foo")
+        assert results[0] == Document(page_content="foo", id=ids[0])
         results = vs_custom.similarity_search_with_score_by_vector(embedding)
-        assert results[0][0] == Document(page_content="foo")
+        assert results[0][0] == Document(page_content="foo", id=ids[0])
         assert results[0][1] == 0
 
     def test_max_marginal_relevance_search(self, vs_custom):
         results = vs_custom.max_marginal_relevance_search("bar")
-        assert results[0] == Document(page_content="bar")
+        assert results[0] == Document(page_content="bar", id=ids[1])
         results = vs_custom.max_marginal_relevance_search(
             "bar", filter="mycontent = 'boo'"
         )
-        assert results[0] == Document(page_content="boo")
+        assert results[0] == Document(page_content="boo", id=ids[3])
 
     def test_max_marginal_relevance_search_vector(self, vs_custom, embeddings_service):
         embedding = embeddings_service.embed_query("bar")
         results = vs_custom.max_marginal_relevance_search_by_vector(embedding)
-        assert results[0] == Document(page_content="bar")
+        assert results[0] == Document(page_content="bar", id=ids[1])
 
     def test_max_marginal_relevance_search_vector_score(
         self, vs_custom, embeddings_service
@@ -370,9 +369,9 @@ class TestVectorStoreEmbeddingsSync:
         results = vs_custom.max_marginal_relevance_search_with_score_by_vector(
             embedding
         )
-        assert results[0][0] == Document(page_content="bar")
+        assert results[0][0] == Document(page_content="bar", id=ids[1])
 
         results = vs_custom.max_marginal_relevance_search_with_score_by_vector(
             embedding, lambda_mult=0.75, fetch_k=10
         )
-        assert results[0][0] == Document(page_content="bar")
+        assert results[0][0] == Document(page_content="bar", id=ids[1])

--- a/tests/test_vectorstore_search.py
+++ b/tests/test_vectorstore_search.py
@@ -121,7 +121,7 @@ class TestVectorStoreSearch:
             embedding_service=embeddings_service,
             table_name=DEFAULT_TABLE,
         )
-        ids = [str(uuid.uuid4()) for i in range(len(texts))]
+
         await vs.aadd_documents(docs, ids=ids)
         yield vs
 
@@ -203,9 +203,9 @@ class TestVectorStoreSearch:
     async def test_asimilarity_search(self, vs):
         results = await vs.asimilarity_search("foo", k=1)
         assert len(results) == 1
-        assert results == [Document(page_content="foo")]
+        assert results == [Document(page_content="foo", id=ids[0])]
         results = await vs.asimilarity_search("foo", k=1, filter="content = 'bar'")
-        assert results == [Document(page_content="bar")]
+        assert results == [Document(page_content="bar", id=ids[1])]
 
     async def test_asimilarity_search_image(self, image_vs, image_uris):
         results = await image_vs.asimilarity_search_image(image_uris[0], k=1)
@@ -218,16 +218,16 @@ class TestVectorStoreSearch:
     async def test_asimilarity_search_score(self, vs):
         results = await vs.asimilarity_search_with_score("foo")
         assert len(results) == 4
-        assert results[0][0] == Document(page_content="foo")
+        assert results[0][0] == Document(page_content="foo", id=ids[0])
         assert results[0][1] == 0
 
     async def test_asimilarity_search_by_vector(self, vs):
         embedding = embeddings_service.embed_query("foo")
         results = await vs.asimilarity_search_by_vector(embedding)
         assert len(results) == 4
-        assert results[0] == Document(page_content="foo")
+        assert results[0] == Document(page_content="foo", id=ids[0])
         results = await vs.asimilarity_search_with_score_by_vector(embedding)
-        assert results[0][0] == Document(page_content="foo")
+        assert results[0][0] == Document(page_content="foo", id=ids[0])
         assert results[0][1] == 0
 
     async def test_similarity_search_with_relevance_scores_threshold_cosine(self, vs):
@@ -250,7 +250,7 @@ class TestVectorStoreSearch:
             "foo", **score_threshold
         )
         assert len(results) == 1
-        assert results[0][0] == Document(page_content="foo")
+        assert results[0][0] == Document(page_content="foo", id=ids[0])
 
     async def test_similarity_search_with_relevance_scores_threshold_euclidean(
         self, engine
@@ -267,32 +267,32 @@ class TestVectorStoreSearch:
             "foo", **score_threshold
         )
         assert len(results) == 1
-        assert results[0][0] == Document(page_content="foo")
+        assert results[0][0] == Document(page_content="foo", id=ids[0])
 
     async def test_amax_marginal_relevance_search(self, vs):
         results = await vs.amax_marginal_relevance_search("bar")
-        assert results[0] == Document(page_content="bar")
+        assert results[0] == Document(page_content="bar", id=ids[1])
         results = await vs.amax_marginal_relevance_search(
             "bar", filter="content = 'boo'"
         )
-        assert results[0] == Document(page_content="boo")
+        assert results[0] == Document(page_content="boo", id=ids[3])
 
     async def test_amax_marginal_relevance_search_vector(self, vs):
         embedding = embeddings_service.embed_query("bar")
         results = await vs.amax_marginal_relevance_search_by_vector(embedding)
-        assert results[0] == Document(page_content="bar")
+        assert results[0] == Document(page_content="bar", id=ids[1])
 
     async def test_amax_marginal_relevance_search_vector_score(self, vs):
         embedding = embeddings_service.embed_query("bar")
         results = await vs.amax_marginal_relevance_search_with_score_by_vector(
             embedding
         )
-        assert results[0][0] == Document(page_content="bar")
+        assert results[0][0] == Document(page_content="bar", id=ids[1])
 
         results = await vs.amax_marginal_relevance_search_with_score_by_vector(
             embedding, lambda_mult=0.75, fetch_k=10
         )
-        assert results[0][0] == Document(page_content="bar")
+        assert results[0][0] == Document(page_content="bar", id=ids[1])
 
 
 class TestVectorStoreSearchSync:
@@ -390,9 +390,9 @@ class TestVectorStoreSearchSync:
     def test_similarity_search(self, vs_custom):
         results = vs_custom.similarity_search("foo", k=1)
         assert len(results) == 1
-        assert results == [Document(page_content="foo")]
+        assert results == [Document(page_content="foo", id=ids[0])]
         results = vs_custom.similarity_search("foo", k=1, filter="mycontent = 'bar'")
-        assert results == [Document(page_content="bar")]
+        assert results == [Document(page_content="bar", id=ids[1])]
 
     def test_similarity_search_image(self, image_vs, image_uris):
         results = image_vs.similarity_search_image(image_uris[0], k=1)
@@ -402,39 +402,39 @@ class TestVectorStoreSearchSync:
     def test_similarity_search_score(self, vs_custom):
         results = vs_custom.similarity_search_with_score("foo")
         assert len(results) == 4
-        assert results[0][0] == Document(page_content="foo")
+        assert results[0][0] == Document(page_content="foo", id=ids[0])
         assert results[0][1] == 0
 
     def test_similarity_search_by_vector(self, vs_custom):
         embedding = embeddings_service.embed_query("foo")
         results = vs_custom.similarity_search_by_vector(embedding)
         assert len(results) == 4
-        assert results[0] == Document(page_content="foo")
+        assert results[0] == Document(page_content="foo", id=ids[0])
         results = vs_custom.similarity_search_with_score_by_vector(embedding)
-        assert results[0][0] == Document(page_content="foo")
+        assert results[0][0] == Document(page_content="foo", id=ids[0])
         assert results[0][1] == 0
 
     def test_max_marginal_relevance_search(self, vs_custom):
         results = vs_custom.max_marginal_relevance_search("bar")
-        assert results[0] == Document(page_content="bar")
+        assert results[0] == Document(page_content="bar", id=ids[1])
         results = vs_custom.max_marginal_relevance_search(
             "bar", filter="mycontent = 'boo'"
         )
-        assert results[0] == Document(page_content="boo")
+        assert results[0] == Document(page_content="boo", id=ids[3])
 
     def test_max_marginal_relevance_search_vector(self, vs_custom):
         embedding = embeddings_service.embed_query("bar")
         results = vs_custom.max_marginal_relevance_search_by_vector(embedding)
-        assert results[0] == Document(page_content="bar")
+        assert results[0] == Document(page_content="bar", id=ids[1])
 
     def test_max_marginal_relevance_search_vector_score(self, vs_custom):
         embedding = embeddings_service.embed_query("bar")
         results = vs_custom.max_marginal_relevance_search_with_score_by_vector(
             embedding
         )
-        assert results[0][0] == Document(page_content="bar")
+        assert results[0][0] == Document(page_content="bar", id=ids[1])
 
         results = vs_custom.max_marginal_relevance_search_with_score_by_vector(
             embedding, lambda_mult=0.75, fetch_k=10
         )
-        assert results[0][0] == Document(page_content="bar")
+        assert results[0][0] == Document(page_content="bar", id=ids[1])


### PR DESCRIPTION
chore: support ids in Documents and update insert SQL query to upsert

fixes [b/376065787](https://b.corp.google.com/issues/376065787)
