### PR TITLE
chore: Prepare package for upstreaming langchain changes

### DIFF
--- a/src/langchain_google_alloydb_pg/async_vectorstore.py
+++ b/src/langchain_google_alloydb_pg/async_vectorstore.py
@@ -832,7 +832,6 @@ class AsyncAlloyDBVectorStore(VectorStore):
         if index.enable_extension:
             if callable(getattr(index, "create_extension", None)):
                 function = await index.create_extension(self.engine)  # type: ignore
-                print(function)
         else:
             function = index.distance_strategy.index_function
 

--- a/src/langchain_google_alloydb_pg/async_vectorstore.py
+++ b/src/langchain_google_alloydb_pg/async_vectorstore.py
@@ -828,10 +828,13 @@ class AsyncAlloyDBVectorStore(VectorStore):
             await self.adrop_vector_index()
             return
 
-        # Create `alloydb_scann` extension when a `ScaNN` index is applied
-        if index.enable_extension:
-            if callable(getattr(index, "create_extension", None)):
-                function = await index.create_extension(self.engine)  # type: ignore
+        # if extension name is mentioned, create the extension
+        if index.extension_name:
+            async with self.engine.connect() as conn:
+                await conn.execute(
+                    text(f"CREATE EXTENSION IF NOT EXISTS {index.extension_name}")
+                )
+                await conn.commit()
         else:
             function = index.distance_strategy.index_function
 

--- a/src/langchain_google_alloydb_pg/async_vectorstore.py
+++ b/src/langchain_google_alloydb_pg/async_vectorstore.py
@@ -839,7 +839,7 @@ class AsyncAlloyDBVectorStore(VectorStore):
                     text(f"CREATE EXTENSION IF NOT EXISTS {index.extension_name}")
                 )
                 await conn.commit()
-        function = index.distance_strategy.index_function
+        function = index.get_index_function(index.distance_strategy)
 
         filter = f"WHERE ({index.partial_indexes})" if index.partial_indexes else ""
         params = "WITH " + index.index_options()

--- a/src/langchain_google_alloydb_pg/async_vectorstore.py
+++ b/src/langchain_google_alloydb_pg/async_vectorstore.py
@@ -839,9 +839,7 @@ class AsyncAlloyDBVectorStore(VectorStore):
                     text(f"CREATE EXTENSION IF NOT EXISTS {index.extension_name}")
                 )
                 await conn.commit()
-            function = index.distance_strategy.scann_index_function
-        else:
-            function = index.distance_strategy.index_function
+        function = index.distance_strategy.index_function
 
         filter = f"WHERE ({index.partial_indexes})" if index.partial_indexes else ""
         params = "WITH " + index.index_options()

--- a/src/langchain_google_alloydb_pg/async_vectorstore.py
+++ b/src/langchain_google_alloydb_pg/async_vectorstore.py
@@ -839,7 +839,7 @@ class AsyncAlloyDBVectorStore(VectorStore):
                     text(f"CREATE EXTENSION IF NOT EXISTS {index.extension_name}")
                 )
                 await conn.commit()
-        function = index.get_index_function(index.distance_strategy)
+        function = index.get_index_function()
 
         filter = f"WHERE ({index.partial_indexes})" if index.partial_indexes else ""
         params = "WITH " + index.index_options()

--- a/src/langchain_google_alloydb_pg/async_vectorstore.py
+++ b/src/langchain_google_alloydb_pg/async_vectorstore.py
@@ -835,6 +835,7 @@ class AsyncAlloyDBVectorStore(VectorStore):
                     text(f"CREATE EXTENSION IF NOT EXISTS {index.extension_name}")
                 )
                 await conn.commit()
+            function = index.distance_strategy.scann_index_function
         else:
             function = index.distance_strategy.index_function
 

--- a/src/langchain_google_alloydb_pg/indexes.py
+++ b/src/langchain_google_alloydb_pg/indexes.py
@@ -25,8 +25,10 @@ class StrategyMixin:
     search_function: str
     index_function: str
 
+
 class DistanceStrategy(StrategyMixin, enum.Enum):
     """Enumerator of the Distance strategies."""
+
     EUCLIDEAN = "<->", "l2_distance", "vector_l2_ops"
     COSINE_DISTANCE = "<=>", "cosine_distance", "vector_cosine_ops"
     INNER_PRODUCT = "<#>", "inner_product", "vector_ip_ops"
@@ -168,12 +170,13 @@ class ScaNNIndex(BaseIndex):
 
     class DistanceStrategy(StrategyMixin, enum.Enum):
         """Enumerator of the Distance strategies."""
+
         EUCLIDEAN = "<->", "l2_distance", "l2"
         COSINE_DISTANCE = "<=>", "cosine_distance", "cosine"
         INNER_PRODUCT = "<#>", "inner_product", "dot_prod"
 
     distance_strategy: DistanceStrategy = field(
-        default_factory=lambda: ScaNNIndex.DistanceStrategy.COSINE_DISTANCE # type: ignore
+        default_factory=lambda: ScaNNIndex.DistanceStrategy.COSINE_DISTANCE  # type: ignore
     )
 
     def index_options(self) -> str:

--- a/src/langchain_google_alloydb_pg/indexes.py
+++ b/src/langchain_google_alloydb_pg/indexes.py
@@ -24,15 +24,12 @@ class StrategyMixin:
     operator: str
     search_function: str
     index_function: str
-    scann_index_function: str
-
 
 class DistanceStrategy(StrategyMixin, enum.Enum):
     """Enumerator of the Distance strategies."""
-
-    EUCLIDEAN = "<->", "l2_distance", "vector_l2_ops", "l2"
-    COSINE_DISTANCE = "<=>", "cosine_distance", "vector_cosine_ops", "cosine"
-    INNER_PRODUCT = "<#>", "inner_product", "vector_ip_ops", "dot_product"
+    EUCLIDEAN = "<->", "l2_distance", "vector_l2_ops"
+    COSINE_DISTANCE = "<=>", "cosine_distance", "vector_cosine_ops"
+    INNER_PRODUCT = "<#>", "inner_product", "vector_ip_ops"
 
 
 DEFAULT_DISTANCE_STRATEGY: DistanceStrategy = DistanceStrategy.COSINE_DISTANCE
@@ -168,6 +165,16 @@ class ScaNNIndex(BaseIndex):
         default="sq8", init=False
     )  # Disable `quantizer` initialization currently only supports the value "sq8"
     extension_name: str = "alloydb_scann"
+
+    class DistanceStrategy(StrategyMixin, enum.Enum):
+        """Enumerator of the Distance strategies."""
+        EUCLIDEAN = "<->", "l2_distance", "l2"
+        COSINE_DISTANCE = "<=>", "cosine_distance", "cosine"
+        INNER_PRODUCT = "<#>", "inner_product", "dot_prod"
+
+    distance_strategy: DistanceStrategy = field(
+        default_factory=lambda: ScaNNIndex.DistanceStrategy.COSINE_DISTANCE # type: ignore
+    )
 
     def index_options(self) -> str:
         """Set index query options for vector store initialization."""

--- a/src/langchain_google_alloydb_pg/indexes.py
+++ b/src/langchain_google_alloydb_pg/indexes.py
@@ -175,7 +175,7 @@ class ScaNNIndex(BaseIndex):
         """Set index query options for vector store initialization."""
         return f"(num_leaves = {self.num_leaves}, quantizer = {self.quantizer})"
 
-    async def create_index(self, engine: AsyncEngine) -> str:
+    async def create_extension(self, engine: AsyncEngine) -> str:
         """Creates a ScaNN index in the DB.
 
         Args:

--- a/src/langchain_google_alloydb_pg/indexes.py
+++ b/src/langchain_google_alloydb_pg/indexes.py
@@ -18,6 +18,9 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Optional
 
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine
+
 
 @dataclass
 class StrategyMixin:
@@ -47,6 +50,7 @@ class BaseIndex(ABC):
         default_factory=lambda: DistanceStrategy.COSINE_DISTANCE
     )
     partial_indexes: Optional[list[str]] = None
+    enable_extension: Optional[bool] = False
 
     @abstractmethod
     def index_options(self) -> str:
@@ -170,6 +174,20 @@ class ScaNNIndex(BaseIndex):
     def index_options(self) -> str:
         """Set index query options for vector store initialization."""
         return f"(num_leaves = {self.num_leaves}, quantizer = {self.quantizer})"
+
+    async def create_index(self, engine: AsyncEngine) -> str:
+        """Creates a ScaNN index in the DB.
+
+        Args:
+            engine(AsyncEngine): connection pool to the database
+
+        Returns:
+            The DistanceStrategy to be used with the index
+        """
+        async with engine.connect() as conn:
+            await conn.execute(text("CREATE EXTENSION IF NOT EXISTS alloydb_scann"))
+            await conn.commit()
+        return self.distance_strategy.scann_index_function
 
 
 @dataclass

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -32,17 +32,21 @@ class TestAlloyDBIndex:
         assert DistanceStrategy.EUCLIDEAN.operator == "<->"
         assert DistanceStrategy.EUCLIDEAN.search_function == "l2_distance"
         assert DistanceStrategy.EUCLIDEAN.index_function == "vector_l2_ops"
-        assert DistanceStrategy.EUCLIDEAN.scann_index_function == "l2"
 
         assert DistanceStrategy.COSINE_DISTANCE.operator == "<=>"
         assert DistanceStrategy.COSINE_DISTANCE.search_function == "cosine_distance"
         assert DistanceStrategy.COSINE_DISTANCE.index_function == "vector_cosine_ops"
-        assert DistanceStrategy.COSINE_DISTANCE.scann_index_function == "cosine"
 
         assert DistanceStrategy.INNER_PRODUCT.operator == "<#>"
         assert DistanceStrategy.INNER_PRODUCT.search_function == "inner_product"
         assert DistanceStrategy.INNER_PRODUCT.index_function == "vector_ip_ops"
-        assert DistanceStrategy.INNER_PRODUCT.scann_index_function == "dot_product"
+
+        scann_index = ScaNNIndex(distance_strategy=DistanceStrategy.EUCLIDEAN)
+        assert scann_index.get_index_function() == "l2"
+        scann_index = ScaNNIndex(distance_strategy=DistanceStrategy.COSINE_DISTANCE)
+        assert scann_index.get_index_function() == "cosine"
+        scann_index = ScaNNIndex(distance_strategy=DistanceStrategy.INNER_PRODUCT)
+        assert scann_index.get_index_function() == "dot_prod"
 
     def test_hnsw_index(self):
         index = HNSWIndex(name="test_index", m=32, ef_construction=128)

--- a/tests/test_vectorstore_index.py
+++ b/tests/test_vectorstore_index.py
@@ -297,16 +297,12 @@ class TestAsyncIndex:
         await vs.adrop_vector_index()
 
     async def test_aapply_alloydb_scann_index_ScaNN(self, omni_vs):
-        index = ScaNNIndex(
-            distance_strategy=DistanceStrategy.EUCLIDEAN, enable_extension=True
-        )
+        index = ScaNNIndex(distance_strategy=DistanceStrategy.EUCLIDEAN)
         await omni_vs.aset_maintenance_work_mem(index.num_leaves, VECTOR_SIZE)
         await omni_vs.aapply_vector_index(index, concurrently=True)
         assert await omni_vs.ais_valid_index(DEFAULT_INDEX_NAME_OMNI)
         index = ScaNNIndex(
-            name="secondindex",
-            distance_strategy=DistanceStrategy.COSINE_DISTANCE,
-            enable_extension=True,
+            name="secondindex", distance_strategy=DistanceStrategy.COSINE_DISTANCE
         )
         await omni_vs.aapply_vector_index(index)
         assert await omni_vs.ais_valid_index("secondindex")

--- a/tests/test_vectorstore_index.py
+++ b/tests/test_vectorstore_index.py
@@ -297,13 +297,16 @@ class TestAsyncIndex:
         await vs.adrop_vector_index()
 
     async def test_aapply_alloydb_scann_index_ScaNN(self, omni_vs):
-        index = ScaNNIndex(distance_strategy=DistanceStrategy.EUCLIDEAN)
+        index = ScaNNIndex(
+            distance_strategy=DistanceStrategy.EUCLIDEAN, enable_extension=True
+        )
         await omni_vs.aset_maintenance_work_mem(index.num_leaves, VECTOR_SIZE)
         await omni_vs.aapply_vector_index(index, concurrently=True)
         assert await omni_vs.ais_valid_index(DEFAULT_INDEX_NAME_OMNI)
         index = ScaNNIndex(
             name="secondindex",
             distance_strategy=DistanceStrategy.COSINE_DISTANCE,
+            enable_extension=True,
         )
         await omni_vs.aapply_vector_index(index)
         assert await omni_vs.ais_valid_index("secondindex")


### PR DESCRIPTION
chore: Prepare package for upstreaming langchain changes

For bug - [b/401013845](https://b.corp.google.com/issues/401013845)

This PR prepares the package for upstreaming changes to langchain-postgres.
The changes are restricted to vectorstore.
- Instead of checking for `ScaNNIndex` class instance while applying a vector index, the integration now relies on the use to specify if the `ScaNNIndex` extension needs to be created .
- Removes the check for AlloyDBEmbeddings and checks if the provided embedding class has the function `embed_query_inline`

 These changes are made so as to not have a circular import on upstreaming these changes to langchain-postgres
