### PR TITLE
refactor: parse embedding dimensions as float[] for numpyV2

### DIFF
--- a/src/langchain_google_alloydb_pg/async_vectorstore.py
+++ b/src/langchain_google_alloydb_pg/async_vectorstore.py
@@ -247,7 +247,11 @@ class AsyncAlloyDBVectorStore(VectorStore):
                 else ""
             )
             insert_stmt = f'INSERT INTO "{self.schema_name}"."{self.table_name}"("{self.id_column}", "{self.content_column}", "{self.embedding_column}"{metadata_col_names}'
-            values = {"id": id, "content": content, "embedding": str(embedding)}
+            values = {
+                "id": id,
+                "content": content,
+                "embedding": str([float(dimension) for dimension in embedding]),
+            }
             values_stmt = "VALUES (:id, :content, :embedding"
             if not embedding and isinstance(self.embedding_service, AlloyDBEmbeddings):
                 values_stmt = f"VALUES (:id, :content, {self.embedding_service.embed_query_inline(content)}"
@@ -561,7 +565,7 @@ class AsyncAlloyDBVectorStore(VectorStore):
         ):
             query_embedding = self.embedding_service.embed_query_inline(kwargs["query"])
         else:
-            query_embedding = f"'{embedding}'"
+            query_embedding = f"'{[float(dimension) for dimension in embedding]}'"
         stmt = f'SELECT {column_names}, {search_function}({self.embedding_column}, {query_embedding}) as distance FROM "{self.schema_name}"."{self.table_name}" {filter} ORDER BY {self.embedding_column} {operator} {query_embedding} LIMIT {k};'
         if self.index_query_options:
             async with self.engine.connect() as conn:

--- a/src/langchain_google_alloydb_pg/utils/pgvector_migrator.py
+++ b/src/langchain_google_alloydb_pg/utils/pgvector_migrator.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import asyncio
+import json
 import warnings
 from typing import Any, AsyncIterator, Iterator, Optional, Sequence, TypeVar
 
@@ -100,7 +101,7 @@ async def __concurrent_batch_insert(
             asyncio.ensure_future(
                 vector_store.aadd_embeddings(
                     texts=[data.document for data in batch_data],
-                    embeddings=[data.embedding for data in batch_data],
+                    embeddings=[json.loads(data.embedding) for data in batch_data],
                     metadatas=[data.cmetadata for data in batch_data],
                     ids=[data.id for data in batch_data],
                 )

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -132,7 +132,9 @@ class TestEngineAsync:
         id = str(uuid.uuid4())
         content = "coffee"
         embedding = await embeddings_service.aembed_query(content)
-        stmt = f"INSERT INTO {DEFAULT_TABLE} (langchain_id, content, embedding) VALUES ('{id}', '{content}','{embedding}');"
+        # Note: DeterministicFakeEmbedding generates a numpy array, converting to list a list of float values
+        embedding_string = [float(dimension) for dimension in embedding]
+        stmt = f"INSERT INTO {DEFAULT_TABLE} (langchain_id, content, embedding) VALUES ('{id}', '{content}','{embedding_string}');"
         await aexecute(engine, stmt)
 
     async def test_engine_args(self, engine):
@@ -365,7 +367,9 @@ class TestEngineSync:
         id = str(uuid.uuid4())
         content = "coffee"
         embedding = await embeddings_service.aembed_query(content)
-        stmt = f"INSERT INTO {DEFAULT_TABLE_SYNC} (langchain_id, content, embedding) VALUES ('{id}', '{content}','{embedding}');"
+        # Note: DeterministicFakeEmbedding generates a numpy array, converting to list a list of float values
+        embedding_string = [float(dimension) for dimension in embedding]
+        stmt = f"INSERT INTO {DEFAULT_TABLE_SYNC} (langchain_id, content, embedding) VALUES ('{id}', '{content}','{embedding_string}');"
         await aexecute(engine, stmt)
 
     async def test_init_table_custom(self, engine):

--- a/tests/util_tests/test_pgvector_migrator.py
+++ b/tests/util_tests/test_pgvector_migrator.py
@@ -240,7 +240,7 @@ class TestPgvectorengine:
             [
                 mock.Mock(
                     document=f"doc{i}",
-                    embedding=[i],
+                    embedding=f"[{i}]",
                     cmetadata={"meta": f"data{i}"},
                     id=f"id{i}",
                 )


### PR DESCRIPTION
Per [this comment](https://github.com/googleapis/langchain-google-alloydb-pg-python/pull/327#issuecomment-2685689004), separating out the code changes for numpy #V2.

This change is needed because when using numpy V2, if a numpy array is converted to string then it comes as numpy objects rather than float array. [ref](https://github.com/googleapis/langchain-google-cloud-sql-pg-python/issues/247#issuecomment-2652914015)

## Changes include:
1. Parsing embedding dimensions individually for accommodating numpy V2 values.
    - Includes fixes for `utils/pgvector_migrator.py`
3. Updating tests accordingly.



