### PR TITLE
chore(deps): update connectors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-google-cloud-alloydb-connector[asyncpg]==1.7.0
+google-cloud-alloydb-connector[asyncpg]==1.8.0
 google-cloud-storage==3.1.0
 langchain-core==0.3.41
 numpy==2.2.3; python_version > "3.9"


### PR DESCRIPTION
The new version of connectors for Alloy DB are leading to test failures, ref tests in https://github.com/googleapis/langchain-google-alloydb-pg-python/pull/381.

This PR pins the issue to connector's latest version so that other packages can be unblocked from version updates.