### PR TITLE
chore(lint): fix lint in async checkpointer tests

### DIFF
--- a/tests/test_async_checkpoint.py
+++ b/tests/test_async_checkpoint.py
@@ -136,6 +136,7 @@ async def async_engine():
     await aexecute(async_engine, f'DROP TABLE IF EXISTS "{table_name}"')
     await aexecute(async_engine, f'DROP TABLE IF EXISTS "{table_name_writes}"')
     await async_engine.close()
+    await async_engine._connector.close()
 
 
 @pytest_asyncio.fixture

--- a/tests/test_async_checkpoint.py
+++ b/tests/test_async_checkpoint.py
@@ -136,7 +136,6 @@ async def async_engine():
     await aexecute(async_engine, f'DROP TABLE IF EXISTS "{table_name}"')
     await aexecute(async_engine, f'DROP TABLE IF EXISTS "{table_name_writes}"')
     await async_engine.close()
-    await async_engine._connector.close()
 
 
 @pytest_asyncio.fixture
@@ -175,7 +174,7 @@ async def test_checkpoint_async(
 
 
 @pytest.fixture
-def test_data():
+def test_data() -> dict[str, Any]:
     """Fixture providing test data for checkpoint tests."""
     config_0: RunnableConfig = {"configurable": {"thread_id": "1", "checkpoint_ns": ""}}
     config_1: RunnableConfig = {
@@ -226,13 +225,13 @@ def test_data():
         "source": "input",
         "step": 2,
         "writes": {},
-        "parents": 1,
+        "parents": 1,  # type: ignore[typeddict-item]
     }
     metadata_2: CheckpointMetadata = {
         "source": "loop",
         "step": 1,
         "writes": {"foo": "bar"},
-        "parents": None,
+        "parents": None,  # type: ignore[typeddict-item]
     }
     metadata_3: CheckpointMetadata = {}
 

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -105,6 +105,7 @@ async def engine():
     await aexecute(engine, f'DROP TABLE IF EXISTS "{table_name}"')
     await aexecute(engine, f'DROP TABLE IF EXISTS "{table_name_writes}"')
     await engine.close()
+    await engine._connector.close()
 
 
 @pytest_asyncio.fixture

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -105,7 +105,6 @@ async def engine():
     await aexecute(engine, f'DROP TABLE IF EXISTS "{table_name}"')
     await aexecute(engine, f'DROP TABLE IF EXISTS "{table_name_writes}"')
     await engine.close()
-    await engine._connector.close()
 
 
 @pytest_asyncio.fixture
@@ -122,7 +121,6 @@ async def async_engine():
     await aexecute(async_engine, f'DROP TABLE IF EXISTS "{table_name_async}"')
     await aexecute(async_engine, f'DROP TABLE IF EXISTS "{table_name_writes_async}"')
     await async_engine.close()
-    await async_engine._connector.close()
 
 
 @pytest_asyncio.fixture
@@ -202,7 +200,7 @@ def test_checkpoint_table(engine: Any) -> None:
 
 
 @pytest.fixture
-def test_data():
+def test_data() -> dict[str, Any]:
     """Fixture providing test data for checkpoint tests."""
     config_0: RunnableConfig = {"configurable": {"thread_id": "1", "checkpoint_ns": ""}}
     config_1: RunnableConfig = {
@@ -253,13 +251,13 @@ def test_data():
         "source": "input",
         "step": 2,
         "writes": {},
-        "parents": 1,
+        "parents": 1,  # type: ignore[typeddict-item]
     }
     metadata_2: CheckpointMetadata = {
         "source": "loop",
         "step": 1,
         "writes": {"foo": "bar"},
-        "parents": None,
+        "parents": None,  # type: ignore[typeddict-item]
     }
     metadata_3: CheckpointMetadata = {}
 

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -122,6 +122,7 @@ async def async_engine():
     await aexecute(async_engine, f'DROP TABLE IF EXISTS "{table_name_async}"')
     await aexecute(async_engine, f'DROP TABLE IF EXISTS "{table_name_writes_async}"')
     await async_engine.close()
+    await async_engine._connector.close()
 
 
 @pytest_asyncio.fixture


### PR DESCRIPTION
Lint seems to be failing for checkpointer tests, [ref test log](https://github.com/googleapis/langchain-google-alloydb-pg-python/actions/runs/14622579181/job/41026159411?pr=381) in another PR: https://github.com/googleapis/langchain-google-alloydb-pg-python/pull/381


Reviewer point:

1. Added comments for code suggestions. If `connectors.close` is not needed, reject the suggestions. Else, add them to a commit during review.