### PR TITLE
chore: separate renovate bot PRs for samples and non-samples

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,6 +19,10 @@
   ],
   packageRules: [
     {
+      matchFileNames: ["samples/**"],
+      groupName: "samples-deps",
+    },
+    {
       groupName: 'GitHub Actions',
       matchManagers: [
         'github-actions',
@@ -36,6 +40,7 @@
     },
     {
       groupName: 'python-nonmajor',
+      ignorePaths: ["samples/**"],
       matchCategories: [
         'python',
       ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,7 +20,7 @@
   packageRules: [
     {
       matchFileNames: ["samples/**"],
-      groupName: "samples-deps",
+      groupName: "Samples",
     },
     {
       groupName: 'GitHub Actions',


### PR DESCRIPTION
This PR intends to force the renovate bot PRs to not mixup the dependency upgrade in `samples` folder with others.

**Change:** A new package rule is added which would make the renovate bot do a separate PRs for `samples` folder and all dependency upgrades which go in that folder including, `samples/**requirements.txt`, .

## Reviewer points:
1. Is `ignorePaths` [ref](https://docs.renovatebot.com/configuration-options/#ignorepaths) the correct tag, other promising contenders are `matchFileNames` (using a regex with a negation caret ^), `includePaths`
2. The above are not [packageRules](https://docs.renovatebot.com/configuration-options/#packagerules), there's no way to know. Should we use `matchPackageNames` instead (using a regex with a negation caret ^)?


<details>

<summary> 
<h3>Log for validating renovate bot config</h3>
</summary>

(base) ➜  langchain-google-alloydb-pg-python git:(main) ✗ npx --yes --package renovate -- renovate-config-validator
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'renovate@39.264.0',
npm WARN EBADENGINE   required: { node: '^20.15.1 || ^22.11.0', pnpm: '^10.0.0' },
npm WARN EBADENGINE   current: { node: 'v21.7.3', npm: '10.5.0' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@renovatebot/kbpgp@4.0.1',
npm WARN EBADENGINE   required: { node: '^20.9.0 || ^22.11.0', pnpm: '^9.0.0' },
npm WARN EBADENGINE   current: { node: 'v21.7.3', npm: '10.5.0' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@renovatebot/pep440@4.1.0',
npm WARN EBADENGINE   required: { node: '^20.9.0 || ^22.11.0', pnpm: '^9.0.0' },
npm WARN EBADENGINE   current: { node: 'v21.7.3', npm: '10.5.0' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@renovatebot/ruby-semver@4.0.0',
npm WARN EBADENGINE   required: { node: '^20.9.0 || ^22.11.0', pnpm: '^9.0.0' },
npm WARN EBADENGINE   current: { node: 'v21.7.3', npm: '10.5.0' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'glob@11.0.1',
npm WARN EBADENGINE   required: { node: '20 || >=22' },
npm WARN EBADENGINE   current: { node: 'v21.7.3', npm: '10.5.0' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'minimatch@10.0.1',
npm WARN EBADENGINE   required: { node: '20 || >=22' },
npm WARN EBADENGINE   current: { node: 'v21.7.3', npm: '10.5.0' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'jackspeak@4.1.0',
npm WARN EBADENGINE   required: { node: '20 || >=22' },
npm WARN EBADENGINE   current: { node: 'v21.7.3', npm: '10.5.0' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'path-scurry@2.0.0',
npm WARN EBADENGINE   required: { node: '20 || >=22' },
npm WARN EBADENGINE   current: { node: 'v21.7.3', npm: '10.5.0' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'lru-cache@11.1.0',
npm WARN EBADENGINE   required: { node: '20 || >=22' },
npm WARN EBADENGINE   current: { node: 'v21.7.3', npm: '10.5.0' }
npm WARN EBADENGINE }
npm WARN deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
npm WARN deprecated rimraf@2.4.5: Rimraf versions prior to v4 are no longer supported
npm WARN deprecated boolean@3.2.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm WARN deprecated glob@6.0.4: Glob versions prior to v9 are no longer supported
 INFO: Validating .github/renovate.json5
 INFO: Config validated successfully
npm notice 
npm notice New major version of npm available! 10.5.0 -> 11.3.0
npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.3.0
npm notice Run npm install -g npm@11.3.0 to update!
npm notice 
(base) ➜  langchain-google-alloydb-pg-python git:(main) ✗


</details>