### PR TITLE
chore(deps): update connectors

### DIFF
--- a/samples/index_tuning_sample/create_vector_embeddings.py
+++ b/samples/index_tuning_sample/create_vector_embeddings.py
@@ -146,7 +146,6 @@ async def main():
     documents = load_csv_documents()
     await create_vector_store_table(documents, engine)
     await engine.close()
-    await engine._connector.close()
 
 
 if __name__ == "__main__":

--- a/samples/index_tuning_sample/index_search.py
+++ b/samples/index_tuning_sample/index_search.py
@@ -248,7 +248,6 @@ async def main():
             f"IVF average recall: {ivf_average_recall}       IVF latency: {ivf_average_latency}"
         )
     await vector_store._engine.close()
-    await vector_store._engine._connector.close()
 
 
 if __name__ == "__main__":

--- a/samples/langchain_on_vertexai/clean_up.py
+++ b/samples/langchain_on_vertexai/clean_up.py
@@ -49,7 +49,6 @@ async def delete_databases():
         await conn.execute(text(f"DROP TABLE IF EXISTS {TABLE_NAME}"))
         await conn.execute(text(f"DROP TABLE IF EXISTS {CHAT_TABLE_NAME}"))
     await engine.close()
-    await engine._connector.close()
 
 
 def delete_engines():

--- a/tests/test_async_checkpoint.py
+++ b/tests/test_async_checkpoint.py
@@ -136,7 +136,6 @@ async def async_engine():
     await aexecute(async_engine, f'DROP TABLE IF EXISTS "{table_name}"')
     await aexecute(async_engine, f'DROP TABLE IF EXISTS "{table_name_writes}"')
     await async_engine.close()
-    await async_engine._connector.close()
 
 
 @pytest_asyncio.fixture

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -105,7 +105,6 @@ async def engine():
     await aexecute(engine, f'DROP TABLE IF EXISTS "{table_name}"')
     await aexecute(engine, f'DROP TABLE IF EXISTS "{table_name_writes}"')
     await engine.close()
-    await engine._connector.close()
 
 
 @pytest_asyncio.fixture
@@ -122,7 +121,6 @@ async def async_engine():
     await aexecute(async_engine, f'DROP TABLE IF EXISTS "{table_name_async}"')
     await aexecute(async_engine, f'DROP TABLE IF EXISTS "{table_name_writes_async}"')
     await async_engine.close()
-    await async_engine._connector.close()
 
 
 @pytest_asyncio.fixture

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -126,7 +126,6 @@ class TestEngineAsync:
         await aexecute(engine, f'DROP TABLE "{DEFAULT_TABLE}"')
         await aexecute(engine, f'DROP TABLE "{INT_ID_CUSTOM_TABLE}"')
         await engine.close()
-        await engine._connector.close()
 
     async def test_init_table(self, engine):
         await engine.ainit_vectorstore_table(DEFAULT_TABLE, VECTOR_SIZE)
@@ -312,7 +311,6 @@ class TestEngineAsync:
         assert engine
         await aexecute(engine, "SELECT 1")
         await engine.close()
-        await engine._connector.close()
 
     async def test_ainit_checkpoint_writes_table(self, engine):
         table_name = f"checkpoint{uuid.uuid4()}"
@@ -398,7 +396,6 @@ class TestEngineSync:
         await aexecute(engine, f'DROP TABLE "{DEFAULT_TABLE_SYNC}"')
         await aexecute(engine, f'DROP TABLE "{INT_ID_CUSTOM_TABLE_SYNC}"')
         await engine.close()
-        await engine._connector.close()
 
     async def test_init_table(self, engine):
         engine.init_vectorstore_table(DEFAULT_TABLE_SYNC, VECTOR_SIZE)
@@ -509,7 +506,6 @@ class TestEngineSync:
         assert engine
         await aexecute(engine, "SELECT 1")
         await engine.close()
-        await engine._connector.close()
 
     async def test_init_checkpoints_table(self, engine):
         table_name = f"checkpoint{uuid.uuid4()}"

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -64,7 +64,6 @@ class TestAlloyDBModelManager:
         )
         yield engine
         await engine.close()
-        await engine._connector.close()
 
     @pytest_asyncio.fixture(scope="module")
     async def model_manager(self, engine):

--- a/tests/test_standard_test_suite.py
+++ b/tests/test_standard_test_suite.py
@@ -91,7 +91,6 @@ class TestStandardSuiteSync(VectorStoreIntegrationTests):
         yield sync_engine
         await aexecute(sync_engine, f'DROP TABLE IF EXISTS "{DEFAULT_TABLE_SYNC}"')
         await sync_engine.close()
-        await sync_engine._connector.close()
 
     @pytest.fixture(scope="function")
     def vectorstore(self, sync_engine):
@@ -155,7 +154,6 @@ class TestStandardSuiteAsync(VectorStoreIntegrationTests):
         yield async_engine
         await aexecute(async_engine, f'DROP TABLE IF EXISTS "{DEFAULT_TABLE}"')
         await async_engine.close()
-        await async_engine._connector.close()
 
     @pytest_asyncio.fixture(loop_scope="function")
     async def vectorstore(self, async_engine):

--- a/tests/test_vectorstore.py
+++ b/tests/test_vectorstore.py
@@ -131,7 +131,6 @@ class TestVectorStore:
         yield engine
         await aexecute(engine, f'DROP TABLE IF EXISTS "{DEFAULT_TABLE}"')
         await engine.close()
-        await engine._connector.close()
 
     @pytest_asyncio.fixture(scope="class")
     async def vs(self, engine):
@@ -515,7 +514,6 @@ class TestVectorStore:
 
             await aexecute(engine, f"DROP TABLE {table_name}")
             await engine.close()
-            await engine._connector.close()
 
     async def test_from_engine_loop_connector(
         self,
@@ -619,7 +617,6 @@ class TestVectorStore:
         assert len(results) == 2
         await aexecute(engine, f"DROP TABLE {table_name}")
         await engine.close()
-        await engine._connector.close()
 
     async def test_from_engine_loop(
         self,
@@ -660,7 +657,6 @@ class TestVectorStore:
         assert len(results) == 2
         await aexecute(engine, f"DROP TABLE {table_name}")
         await engine.close()
-        await engine._connector.close()
 
     def test_get_table_name(self, vs):
         assert vs.get_table_name() == DEFAULT_TABLE


### PR DESCRIPTION
The new version of connectors are leading to test failures, ref tests in https://github.com/googleapis/langchain-google-alloydb-pg-python/pull/424. The errors ([GCB Logs](https://pantheon.corp.google.com/cloud-build/builds;region=us-central1/a47c3365-bdd6-48d3-a7d0-1bba1a291781?project=langchain-alloydb-testing&e=13802955&mods=logs_tg_staging&invt=AbyJ7Q&inv=1)) seem like coming from an additional connector close, which is now removed.

Additionally, a tech debt is added towards reconsidering an additional connector close if the underlying behavior of connectors change. ref: b/414134821