### PR TITLE
feat: Update AlloyDBModel to support google_ml_extension v1.5.3

### DIFF
--- a/src/langchain_google_alloydb_pg/model_manager.py
+++ b/src/langchain_google_alloydb_pg/model_manager.py
@@ -214,7 +214,7 @@ class AlloyDBModelManager:
         query = f"""SELECT * FROM
                 google_ml.list_model('{model_id}')
                 AS t(model_id VARCHAR,
-                model_availability VARCHAR,
+                model_availability text,
                 model_request_url VARCHAR,
                 model_provider google_ml.model_provider,
                 model_type google_ml.model_type,


### PR DESCRIPTION
The parameter `model_availability` was added to the return type in the function `list_mode()` in v1.5.3  of the google_ml_extension causing failures across tests. This PR fixes the test failures and updates the model to support v1.5.3 
