### PR TITLE
fix: avoid mutable default argument for metadata_columns

### DIFF
--- a/src/langchain_google_alloydb_pg/engine.py
+++ b/src/langchain_google_alloydb_pg/engine.py
@@ -436,8 +436,9 @@ class AlloyDBEngine(PGEngine):
         store_metadata: bool = True,
     ) -> None:
         """
-        Create a table for saving of langchain documents.
-        If table already exists, a DuplicateTableError error is thrown.
+        Initializes a table for storing documents in AlloyDB.
+        This method creates the required schema for storing text data
+        and associated metadata used by LangChain.
 
         Args:
             table_name (str): The PgSQL database table name.

--- a/src/langchain_google_alloydb_pg/engine.py
+++ b/src/langchain_google_alloydb_pg/engine.py
@@ -431,14 +431,12 @@ class AlloyDBEngine(PGEngine):
         table_name: str,
         schema_name: str = "public",
         content_column: str = "page_content",
-        metadata_columns: list[Column] = [],
+        metadata_columns: Optional[list[Column]] = None,
         metadata_json_column: str = "langchain_metadata",
         store_metadata: bool = True,
     ) -> None:
         """
-        Initializes a table for storing documents in AlloyDB.
-        This method creates the required schema for storing text data
-        and associated metadata used by LangChain.
+        Creates a table for storing LangChain documents.
 
         Args:
             table_name (str): The PgSQL database table name.
@@ -446,13 +444,15 @@ class AlloyDBEngine(PGEngine):
                 Default: "public".
             content_column (str): Name of the column to store document content.
                 Default: "page_content".
-            metadata_columns (list[Column]): A list of Columns
+            metadata_columns (Optional[list[Column]]): A list of Columns
                 to create for custom metadata. Optional.
             metadata_json_column (str): The column to store extra metadata in JSON format.
                 Default: "langchain_metadata". Optional.
             store_metadata (bool): Whether to store extra metadata in a metadata column
                 if not described in 'metadata' field list (Default: True).
         """
+        if metadata_columns is None:
+            metadata_columns = []
         query = f"""CREATE TABLE "{schema_name}"."{table_name}"(
             {content_column} TEXT NOT NULL
             """
@@ -473,12 +473,12 @@ class AlloyDBEngine(PGEngine):
         table_name: str,
         schema_name: str = "public",
         content_column: str = "page_content",
-        metadata_columns: list[Column] = [],
+        metadata_columns: Optional[list[Column]] = None,
         metadata_json_column: str = "langchain_metadata",
         store_metadata: bool = True,
     ) -> None:
         """
-        Create a table for saving of langchain documents.
+        Creates a table for storing LangChain documents.
 
         Args:
             table_name (str): The PgSQL database table name.
@@ -486,7 +486,7 @@ class AlloyDBEngine(PGEngine):
                 Default: "public".
             content_column (str): Name of the column to store document content.
                 Default: "page_content".
-            metadata_columns (list[sqlalchemy.Column]): A list of SQLAlchemy Columns
+            metadata_columns (Optional[list[Column]]): A list of SQLAlchemy Columns
                 to create for custom metadata. Optional.
             metadata_json_column (str): The column to store extra metadata in JSON format.
                 Default: "langchain_metadata". Optional.
@@ -512,12 +512,12 @@ class AlloyDBEngine(PGEngine):
         table_name: str,
         schema_name: str = "public",
         content_column: str = "page_content",
-        metadata_columns: list[Column] = [],
+        metadata_columns: Optional[list[Column]] = None,
         metadata_json_column: str = "langchain_metadata",
         store_metadata: bool = True,
     ) -> None:
         """
-        Create a table for saving of langchain documents.
+        Creates a table for storing LangChain documents.
 
         Args:
             table_name (str): The PgSQL database table name.
@@ -525,7 +525,7 @@ class AlloyDBEngine(PGEngine):
                 Default: "public".
             content_column (str): Name of the column to store document content.
                 Default: "page_content".
-            metadata_columns (list[sqlalchemy.Column]): A list of SQLAlchemy Columns
+            metadata_columns (Optional[list[Column]]): A list of SQLAlchemy Columns
                 to create for custom metadata. Optional.
             metadata_json_column (str): The column to store extra metadata in JSON format.
                 Default: "langchain_metadata". Optional.


### PR DESCRIPTION
Fixes a Python mutable default argument issue in metadata_columns.

Replaces default [] with None and initializes safely inside functions:
if metadata_columns is None:
    metadata_columns = []

This prevents unintended shared state across function calls
