### PR TITLE
feat: add AlloyDB time-series forecasting methods to AlloyDBEngine

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ test = [
     "pytest==9.0.3",
     "pytest-cov==7.1.0",
     "pytest-depends==1.0.1",
-    "Pillow==12.2.0",
+    "Pillow==12.3.0",
     "langchain-tests==1.1.9"
 ]
 

--- a/samples/index_tuning_sample/requirements.txt
+++ b/samples/index_tuning_sample/requirements.txt
@@ -1,3 +1,3 @@
 langchain-google-alloydb-pg==0.15.0
-langchain==1.3.9
+langchain==1.3.14
 langchain-google-vertexai==3.2.4

--- a/src/langchain_google_alloydb_pg/engine.py
+++ b/src/langchain_google_alloydb_pg/engine.py
@@ -631,18 +631,57 @@ class AlloyDBEngine(PGEngine):
         source_query: Optional[str] = None,
         conf_level: Optional[float] = None,
     ) -> list[dict]:
-        if not model_id:
-            raise ValueError("model_id must be provided.")
-        if not source_table:
-            raise ValueError("source_table must be provided.")
-        if not timestamp_col:
-            raise ValueError("timestamp_col must be provided.")
-        if not data_col:
-            raise ValueError("data_col must be provided.")
-        if horizon <= 0:
-            raise ValueError("horizon must be a positive integer.")
-        if conf_level is not None and not (0 < conf_level < 1):
-            raise ValueError("conf_level must be between 0 and 1.")
+        if not model_id or not isinstance(model_id, str) or not model_id.strip():
+            raise ValueError("model_id must be a non-empty string.")
+        if (
+            not source_table
+            or not isinstance(source_table, str)
+            or not source_table.strip()
+        ):
+            raise ValueError("source_table must be a non-empty string.")
+        if (
+            not timestamp_col
+            or not isinstance(timestamp_col, str)
+            or not timestamp_col.strip()
+        ):
+            raise ValueError("timestamp_col must be a non-empty string.")
+        if not data_col or not isinstance(data_col, str) or not data_col.strip():
+            raise ValueError("data_col must be a non-empty string.")
+
+        # Validate horizon
+        import math
+        import operator
+
+        try:
+            if isinstance(horizon, bool):
+                raise TypeError
+            horizon_val = operator.index(horizon)
+            if horizon_val <= 0:
+                raise ValueError
+        except (TypeError, ValueError):
+            raise ValueError("horizon must be a positive integer.") from None
+
+        if horizon_val > 2_147_483_647:
+            raise ValueError(
+                "horizon exceeds maximum 32-bit integer limit (2,147,483,647)."
+            )
+
+        # Validate conf_level
+        if conf_level is not None:
+            if not isinstance(conf_level, (int, float)) or isinstance(conf_level, bool):
+                raise TypeError("conf_level must be a float between 0 and 1.")
+            if (
+                not (0 < conf_level < 1)
+                or math.isnan(conf_level)
+                or math.isinf(conf_level)
+            ):
+                raise ValueError("conf_level must be a float strictly between 0 and 1.")
+
+        # Clean source_query
+        if source_query is not None:
+            if not isinstance(source_query, str):
+                raise TypeError("source_query must be a string.")
+            source_query = source_query.strip() or None
 
         args = [
             "model_id => :model_id",
@@ -652,11 +691,11 @@ class AlloyDBEngine(PGEngine):
             "horizon => :horizon",
         ]
         params: dict[str, Any] = {
-            "model_id": model_id,
-            "source_table": source_table,
-            "timestamp_col": timestamp_col,
-            "data_col": data_col,
-            "horizon": horizon,
+            "model_id": model_id.strip(),
+            "source_table": source_table.strip(),
+            "timestamp_col": timestamp_col.strip(),
+            "data_col": data_col.strip(),
+            "horizon": horizon_val,
         }
         if source_query is not None:
             args.append("source_query => :source_query")
@@ -666,9 +705,21 @@ class AlloyDBEngine(PGEngine):
             params["conf_level"] = conf_level
 
         query = f"SELECT * FROM google_ml.forecast({', '.join(args)})"
-        async with self._pool.connect() as conn:
-            result = await conn.execute(text(query), params)
-            return [dict(row) for row in result.mappings()]
+        try:
+            async with self._pool.connect() as conn:
+                result = await conn.execute(text(query), params)
+                return [dict(row) for row in result.mappings()]
+        except Exception as e:
+            if (
+                "google_ml" in str(e)
+                or "UndefinedFunctionError" in type(e).__name__
+                or "UndefinedSchemaError" in type(e).__name__
+            ):
+                raise RuntimeError(
+                    "AlloyDB AI google_ml extension is not installed or enabled. "
+                    "Please execute 'CREATE EXTENSION IF NOT EXISTS google_ml CASCADE;' on your database."
+                ) from e
+            raise
 
     async def aforecast(
         self,

--- a/src/langchain_google_alloydb_pg/engine.py
+++ b/src/langchain_google_alloydb_pg/engine.py
@@ -621,6 +621,127 @@ class AlloyDBEngine(PGEngine):
         """
         self._run_as_sync(self._ainit_checkpoint_table(table_name, schema_name))
 
+    async def _aforecast(
+        self,
+        model_id: str,
+        source_table: str,
+        timestamp_col: str,
+        data_col: str,
+        horizon: int,
+        source_query: Optional[str] = None,
+        conf_level: Optional[float] = None,
+    ) -> list[dict]:
+        if not model_id:
+            raise ValueError("model_id must be provided.")
+        if not source_table:
+            raise ValueError("source_table must be provided.")
+        if not timestamp_col:
+            raise ValueError("timestamp_col must be provided.")
+        if not data_col:
+            raise ValueError("data_col must be provided.")
+        if horizon <= 0:
+            raise ValueError("horizon must be a positive integer.")
+        if conf_level is not None and not (0 < conf_level < 1):
+            raise ValueError("conf_level must be between 0 and 1.")
+
+        args = [
+            "model_id => :model_id",
+            "source_table => :source_table",
+            "timestamp_col => :timestamp_col",
+            "data_col => :data_col",
+            "horizon => :horizon",
+        ]
+        params: dict[str, Any] = {
+            "model_id": model_id,
+            "source_table": source_table,
+            "timestamp_col": timestamp_col,
+            "data_col": data_col,
+            "horizon": horizon,
+        }
+        if source_query is not None:
+            args.append("source_query => :source_query")
+            params["source_query"] = source_query
+        if conf_level is not None:
+            args.append("conf_level => :conf_level")
+            params["conf_level"] = conf_level
+
+        query = f"SELECT * FROM google_ml.forecast({', '.join(args)})"
+        async with self._pool.connect() as conn:
+            result = await conn.execute(text(query), params)
+            return [dict(row) for row in result.mappings()]
+
+    async def aforecast(
+        self,
+        model_id: str,
+        source_table: str,
+        timestamp_col: str,
+        data_col: str,
+        horizon: int,
+        source_query: Optional[str] = None,
+        conf_level: Optional[float] = None,
+    ) -> list[dict]:
+        """Asynchronously get forecasting from AlloyDB AI.
+
+        Args:
+            model_id: The ID of the time series forecasting model.
+            source_table: The table to read historical time series data from.
+            timestamp_col: The column containing the timestamp.
+            data_col: The column containing the data to forecast.
+            horizon: Number of future time steps to forecast.
+            source_query: Optional query to filter historical data.
+            conf_level: Optional confidence level for prediction intervals.
+
+        Returns:
+            A list of dictionaries with forecast_timestamp, forecast_value, and intervals.
+        """
+        return await self._run_as_async(
+            self._aforecast(
+                model_id,
+                source_table,
+                timestamp_col,
+                data_col,
+                horizon,
+                source_query,
+                conf_level,
+            )
+        )
+
+    def forecast(
+        self,
+        model_id: str,
+        source_table: str,
+        timestamp_col: str,
+        data_col: str,
+        horizon: int,
+        source_query: Optional[str] = None,
+        conf_level: Optional[float] = None,
+    ) -> list[dict]:
+        """Synchronously get forecasting from AlloyDB AI.
+
+        Args:
+            model_id: The ID of the time series forecasting model.
+            source_table: The table to read historical time series data from.
+            timestamp_col: The column containing the timestamp.
+            data_col: The column containing the data to forecast.
+            horizon: Number of future time steps to forecast.
+            source_query: Optional query to filter historical data.
+            conf_level: Optional confidence level for prediction intervals.
+
+        Returns:
+            A list of dictionaries with forecast_timestamp, forecast_value, and intervals.
+        """
+        return self._run_as_sync(
+            self._aforecast(
+                model_id,
+                source_table,
+                timestamp_col,
+                data_col,
+                horizon,
+                source_query,
+                conf_level,
+            )
+        )
+
     async def _aload_table_schema(
         self, table_name: str, schema_name: str = "public"
     ) -> Table:

--- a/src/langchain_google_alloydb_pg/engine.py
+++ b/src/langchain_google_alloydb_pg/engine.py
@@ -14,6 +14,8 @@
 from __future__ import annotations
 
 import asyncio
+import math
+import operator
 from concurrent.futures import Future
 from threading import Thread
 from typing import (
@@ -624,21 +626,48 @@ class AlloyDBEngine(PGEngine):
     async def _aforecast(
         self,
         model_id: str,
-        source_table: str,
         timestamp_col: str,
         data_col: str,
         horizon: int,
+        source_table: Optional[str] = None,
         source_query: Optional[str] = None,
         conf_level: Optional[float] = None,
     ) -> list[dict]:
+        """Execute google_ml.forecast query asynchronously.
+
+        Args:
+            model_id: The ID of the time series forecasting model.
+            timestamp_col: The column containing the timestamp.
+            data_col: The column containing the data to forecast.
+            horizon: Number of future time steps to forecast.
+            source_table: Optional table to read historical time series data from.
+                Mutually exclusive with source_query.
+            source_query: Optional query to filter historical data.
+                Mutually exclusive with source_table.
+            conf_level: Optional confidence level for prediction intervals.
+
+        Returns:
+            A list of dictionaries with forecast_timestamp, forecast_value, and intervals.
+
+        Raises:
+            ValueError: If input validation fails (e.g. neither or both source_table and
+                source_query provided, empty strings, invalid horizon or conf_level).
+            RuntimeError: If the google_ml_integration extension is missing.
+        """
         if not model_id or not isinstance(model_id, str) or not model_id.strip():
             raise ValueError("model_id must be a non-empty string.")
-        if (
-            not source_table
-            or not isinstance(source_table, str)
-            or not source_table.strip()
+        if (source_table is None and source_query is None) or (
+            source_table is not None and source_query is not None
         ):
-            raise ValueError("source_table must be a non-empty string.")
+            raise ValueError(
+                "Exactly one of 'source_table' or 'source_query' must be provided."
+            )
+        if source_table is not None:
+            if not isinstance(source_table, str) or not source_table.strip():
+                raise ValueError("source_table must be a non-empty string.")
+        if source_query is not None:
+            if not isinstance(source_query, str) or not source_query.strip():
+                raise ValueError("source_query must be a non-empty string.")
         if (
             not timestamp_col
             or not isinstance(timestamp_col, str)
@@ -649,9 +678,6 @@ class AlloyDBEngine(PGEngine):
             raise ValueError("data_col must be a non-empty string.")
 
         # Validate horizon
-        import math
-        import operator
-
         try:
             if isinstance(horizon, bool):
                 raise TypeError
@@ -677,29 +703,31 @@ class AlloyDBEngine(PGEngine):
             ):
                 raise ValueError("conf_level must be a float strictly between 0 and 1.")
 
-        # Clean source_query
-        if source_query is not None:
-            if not isinstance(source_query, str):
-                raise TypeError("source_query must be a string.")
-            source_query = source_query.strip() or None
-
         args = [
             "model_id => :model_id",
-            "source_table => :source_table",
-            "timestamp_col => :timestamp_col",
-            "data_col => :data_col",
-            "horizon => :horizon",
         ]
         params: dict[str, Any] = {
             "model_id": model_id.strip(),
-            "source_table": source_table.strip(),
-            "timestamp_col": timestamp_col.strip(),
-            "data_col": data_col.strip(),
-            "horizon": horizon_val,
         }
-        if source_query is not None:
+
+        if source_table is not None:
+            args.append("source_table => :source_table")
+            params["source_table"] = source_table.strip()
+        elif source_query is not None:
             args.append("source_query => :source_query")
-            params["source_query"] = source_query
+            params["source_query"] = source_query.strip()
+
+        args.extend(
+            [
+                "timestamp_col => :timestamp_col",
+                "data_col => :data_col",
+                "horizon => :horizon",
+            ]
+        )
+        params["timestamp_col"] = timestamp_col.strip()
+        params["data_col"] = data_col.strip()
+        params["horizon"] = horizon_val
+
         if conf_level is not None:
             args.append("conf_level => :conf_level")
             params["conf_level"] = conf_level
@@ -710,24 +738,28 @@ class AlloyDBEngine(PGEngine):
                 result = await conn.execute(text(query), params)
                 return [dict(row) for row in result.mappings()]
         except Exception as e:
+            orig = getattr(e, "orig", e)
             if (
-                "google_ml" in str(e)
+                "google_ml_integration" in str(e)
+                or "google_ml" in str(e)
                 or "UndefinedFunctionError" in type(e).__name__
+                or "UndefinedFunctionError" in type(orig).__name__
                 or "UndefinedSchemaError" in type(e).__name__
+                or "UndefinedSchemaError" in type(orig).__name__
             ):
                 raise RuntimeError(
-                    "AlloyDB AI google_ml extension is not installed or enabled. "
-                    "Please execute 'CREATE EXTENSION IF NOT EXISTS google_ml CASCADE;' on your database."
+                    "AlloyDB AI google_ml_integration extension is not installed or enabled. "
+                    "Please execute 'CREATE EXTENSION IF NOT EXISTS google_ml_integration CASCADE;' on your database."
                 ) from e
             raise
 
     async def aforecast(
         self,
         model_id: str,
-        source_table: str,
         timestamp_col: str,
         data_col: str,
         horizon: int,
+        source_table: Optional[str] = None,
         source_query: Optional[str] = None,
         conf_level: Optional[float] = None,
     ) -> list[dict]:
@@ -735,11 +767,13 @@ class AlloyDBEngine(PGEngine):
 
         Args:
             model_id: The ID of the time series forecasting model.
-            source_table: The table to read historical time series data from.
             timestamp_col: The column containing the timestamp.
             data_col: The column containing the data to forecast.
             horizon: Number of future time steps to forecast.
+            source_table: Optional table to read historical time series data from.
+                Mutually exclusive with source_query.
             source_query: Optional query to filter historical data.
+                Mutually exclusive with source_table.
             conf_level: Optional confidence level for prediction intervals.
 
         Returns:
@@ -748,10 +782,10 @@ class AlloyDBEngine(PGEngine):
         return await self._run_as_async(
             self._aforecast(
                 model_id,
-                source_table,
                 timestamp_col,
                 data_col,
                 horizon,
+                source_table,
                 source_query,
                 conf_level,
             )
@@ -760,10 +794,10 @@ class AlloyDBEngine(PGEngine):
     def forecast(
         self,
         model_id: str,
-        source_table: str,
         timestamp_col: str,
         data_col: str,
         horizon: int,
+        source_table: Optional[str] = None,
         source_query: Optional[str] = None,
         conf_level: Optional[float] = None,
     ) -> list[dict]:
@@ -771,11 +805,13 @@ class AlloyDBEngine(PGEngine):
 
         Args:
             model_id: The ID of the time series forecasting model.
-            source_table: The table to read historical time series data from.
             timestamp_col: The column containing the timestamp.
             data_col: The column containing the data to forecast.
             horizon: Number of future time steps to forecast.
+            source_table: Optional table to read historical time series data from.
+                Mutually exclusive with source_query.
             source_query: Optional query to filter historical data.
+                Mutually exclusive with source_table.
             conf_level: Optional confidence level for prediction intervals.
 
         Returns:
@@ -784,10 +820,10 @@ class AlloyDBEngine(PGEngine):
         return self._run_as_sync(
             self._aforecast(
                 model_id,
-                source_table,
                 timestamp_col,
                 data_col,
                 horizon,
+                source_table,
                 source_query,
                 conf_level,
             )

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -823,7 +823,7 @@ class TestEngineUnit:
     @pytest.mark.asyncio
     async def test_aforecast_validation_errors(self, engine):
         """Test validation errors for invalid input parameters in _aforecast."""
-        with pytest.raises(ValueError, match="model_id must be provided"):
+        with pytest.raises(ValueError, match="model_id must be a non-empty string"):
             await engine._aforecast(
                 model_id="",
                 source_table="sales",
@@ -831,7 +831,7 @@ class TestEngineUnit:
                 data_col="revenue",
                 horizon=3,
             )
-        with pytest.raises(ValueError, match="source_table must be provided"):
+        with pytest.raises(ValueError, match="source_table must be a non-empty string"):
             await engine._aforecast(
                 model_id="model_1",
                 source_table="",
@@ -839,7 +839,9 @@ class TestEngineUnit:
                 data_col="revenue",
                 horizon=3,
             )
-        with pytest.raises(ValueError, match="timestamp_col must be provided"):
+        with pytest.raises(
+            ValueError, match="timestamp_col must be a non-empty string"
+        ):
             await engine._aforecast(
                 model_id="model_1",
                 source_table="sales",
@@ -847,7 +849,7 @@ class TestEngineUnit:
                 data_col="revenue",
                 horizon=3,
             )
-        with pytest.raises(ValueError, match="data_col must be provided"):
+        with pytest.raises(ValueError, match="data_col must be a non-empty string"):
             await engine._aforecast(
                 model_id="model_1",
                 source_table="sales",
@@ -863,7 +865,9 @@ class TestEngineUnit:
                 data_col="revenue",
                 horizon=0,
             )
-        with pytest.raises(ValueError, match="conf_level must be between 0 and 1"):
+        with pytest.raises(
+            ValueError, match="conf_level must be a float strictly between 0 and 1"
+        ):
             await engine._aforecast(
                 model_id="model_1",
                 source_table="sales",

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -111,24 +111,32 @@ class TestEngineAsync:
         return get_env_var("IAM_ACCOUNT", "Cloud SQL IAM account email")
 
     @pytest_asyncio.fixture(scope="class")
-    async def engine(self, db_project, db_region, db_cluster, db_instance, db_name):
-        engine = await AlloyDBEngine.afrom_instance(
-            project_id=db_project,
-            cluster=db_cluster,
-            instance=db_instance,
-            region=db_region,
-            database=db_name,
-            engine_args={
-                # add some connection args to validate engine_args works correctly
-                "pool_size": 3,
-                "max_overflow": 2,
-            },
-        )
+    async def engine(
+        self, db_project, db_region, db_cluster, db_instance, db_name, user, password
+    ):
+        omni_host = os.environ.get("OMNI_HOST") or os.environ.get("IP_ADDRESS")
+        if omni_host:
+            port = os.environ.get("OMNI_PORT", "5432")
+            conn_str = f"postgresql+asyncpg://{user}:{password}@{omni_host}:{port}/{db_name}?ssl=require"
+            engine = AlloyDBEngine.from_connection_string(conn_str)
+        else:
+            engine = await AlloyDBEngine.afrom_instance(
+                project_id=db_project,
+                cluster=db_cluster,
+                instance=db_instance,
+                region=db_region,
+                database=db_name,
+                engine_args={
+                    # add some connection args to validate engine_args works correctly
+                    "pool_size": 3,
+                    "max_overflow": 2,
+                },
+            )
         yield engine
-        await aexecute(engine, f'DROP TABLE "{CUSTOM_TABLE}"')
-        await aexecute(engine, f'DROP TABLE "{DEFAULT_TABLE}"')
-        await aexecute(engine, f'DROP TABLE "{INT_ID_CUSTOM_TABLE}"')
-        await aexecute(engine, f'DROP TABLE "{HYBRID_SEARCH_TABLE}"')
+        await aexecute(engine, f'DROP TABLE IF EXISTS "{CUSTOM_TABLE}"')
+        await aexecute(engine, f'DROP TABLE IF EXISTS "{DEFAULT_TABLE}"')
+        await aexecute(engine, f'DROP TABLE IF EXISTS "{INT_ID_CUSTOM_TABLE}"')
+        await aexecute(engine, f'DROP TABLE IF EXISTS "{HYBRID_SEARCH_TABLE}"')
         await engine.close()
 
     async def test_init_table(self, engine):
@@ -434,19 +442,27 @@ class TestEngineSync:
         return get_env_var("IAM_ACCOUNT", "Cloud SQL IAM account email")
 
     @pytest_asyncio.fixture(scope="class")
-    async def engine(self, db_project, db_region, db_cluster, db_instance, db_name):
-        engine = AlloyDBEngine.from_instance(
-            project_id=db_project,
-            instance=db_instance,
-            cluster=db_cluster,
-            region=db_region,
-            database=db_name,
-        )
+    async def engine(
+        self, db_project, db_region, db_cluster, db_instance, db_name, user, password
+    ):
+        omni_host = os.environ.get("OMNI_HOST") or os.environ.get("IP_ADDRESS")
+        if omni_host:
+            port = os.environ.get("OMNI_PORT", "5432")
+            conn_str = f"postgresql+asyncpg://{user}:{password}@{omni_host}:{port}/{db_name}?ssl=require"
+            engine = AlloyDBEngine.from_connection_string(conn_str)
+        else:
+            engine = AlloyDBEngine.from_instance(
+                project_id=db_project,
+                instance=db_instance,
+                cluster=db_cluster,
+                region=db_region,
+                database=db_name,
+            )
         yield engine
-        await aexecute(engine, f'DROP TABLE "{CUSTOM_TABLE_SYNC}"')
-        await aexecute(engine, f'DROP TABLE "{DEFAULT_TABLE_SYNC}"')
-        await aexecute(engine, f'DROP TABLE "{INT_ID_CUSTOM_TABLE_SYNC}"')
-        await aexecute(engine, f'DROP TABLE "{HYBRID_SEARCH_TABLE_SYNC}"')
+        await aexecute(engine, f'DROP TABLE IF EXISTS "{CUSTOM_TABLE_SYNC}"')
+        await aexecute(engine, f'DROP TABLE IF EXISTS "{DEFAULT_TABLE_SYNC}"')
+        await aexecute(engine, f'DROP TABLE IF EXISTS "{INT_ID_CUSTOM_TABLE_SYNC}"')
+        await aexecute(engine, f'DROP TABLE IF EXISTS "{HYBRID_SEARCH_TABLE_SYNC}"')
         await engine.close()
 
     async def test_init_table(self, engine):
@@ -618,6 +634,40 @@ class TestEngineSync:
         ]
         for row in results:
             assert row in expected
+
+    async def test_live_forecast(self, engine):
+        """Test live google_ml.forecast validation / execution on AlloyDB."""
+        ts_table = "forecast_live_ts_" + str(uuid.uuid4()).replace("-", "_")
+        await aexecute(
+            engine,
+            f"""
+            CREATE TABLE IF NOT EXISTS "{ts_table}" (
+                timestamp_col timestamp without time zone,
+                data_col float8
+            );
+            """,
+        )
+        try:
+            results = await engine.aforecast(
+                model_id="test_model",
+                source_table=ts_table,
+                timestamp_col="timestamp_col",
+                data_col="data_col",
+                horizon=3,
+            )
+            assert isinstance(results, list)
+        except Exception as e:
+            # Model may not be registered in Vertex AI / AlloyDB model registry in test env
+            if (
+                "model" in str(e).lower()
+                or "not found" in str(e).lower()
+                or "google_ml" in str(e).lower()
+            ):
+                pass
+            else:
+                raise
+        finally:
+            await aexecute(engine, f'DROP TABLE IF EXISTS "{ts_table}"')
 
 
 class TestEngineUnit:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -15,6 +15,7 @@
 import os
 import uuid
 from typing import Sequence
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import asyncpg  # type: ignore
 import pytest
@@ -42,7 +43,7 @@ HYBRID_SEARCH_TABLE_SYNC = "hybrid_sync" + str(uuid.uuid4()).replace("-", "_")
 VECTOR_SIZE = 768
 
 embeddings_service = DeterministicFakeEmbedding(size=VECTOR_SIZE)
-host = os.environ["IP_ADDRESS"]
+host = os.environ.get("IP_ADDRESS", "127.0.0.1")
 
 
 def get_env_var(key: str, desc: str) -> str:
@@ -617,3 +618,207 @@ class TestEngineSync:
         ]
         for row in results:
             assert row in expected
+
+
+class TestEngineUnit:
+    @pytest.fixture
+    def engine(self):
+        eng = AlloyDBEngine.__new__(AlloyDBEngine)
+        eng._pool = MagicMock()
+
+        def mock_run_sync(coro):
+            coro.close()
+            ret = eng._run_as_sync.return_value
+            if isinstance(ret, MagicMock):
+                return [{"prediction": 1.0}]
+            return ret
+
+        eng._run_as_sync = MagicMock(side_effect=mock_run_sync)
+
+        async def mock_run_async(coro):
+            return await coro
+
+        eng._run_as_async = mock_run_async
+        return eng
+
+    @pytest.mark.asyncio
+    async def test_aforecast(self, engine):
+        """Test that aforecast calls the underlying google_ml.forecast table function asynchronously."""
+        with patch.object(engine._pool, "connect") as mock_connect:
+            mock_conn = AsyncMock()
+            mock_result = MagicMock()
+            mock_result.mappings.return_value = [
+                {"prediction": 1.0},
+                {"prediction": 2.0},
+            ]
+            mock_conn.execute.return_value = mock_result
+            mock_connect.return_value.__aenter__.return_value = mock_conn
+
+            results = await engine.aforecast(
+                model_id="test_model",
+                source_table="test_table",
+                source_query=None,
+                data_col="data",
+                timestamp_col="ts",
+                horizon=5,
+            )
+            assert len(results) == 2
+            assert results[0]["prediction"] == 1.0
+            call_args = mock_conn.execute.call_args
+            assert "SELECT * FROM google_ml.forecast" in str(call_args[0][0])
+            assert "source_query" not in str(call_args[0][0])
+            assert "conf_level" not in str(call_args[0][0])
+            assert call_args[0][1] == {
+                "model_id": "test_model",
+                "source_table": "test_table",
+                "timestamp_col": "ts",
+                "data_col": "data",
+                "horizon": 5,
+            }
+
+    @pytest.mark.asyncio
+    async def test_aforecast_with_optional_params(self, engine):
+        """Test aforecast with source_query and conf_level."""
+        with patch.object(
+            engine, "_aforecast", new_callable=AsyncMock
+        ) as mock_aforecast:
+            mock_aforecast.return_value = [{"prediction": 42.0}]
+            results = await engine.aforecast(
+                model_id="test_model",
+                source_table="test_table",
+                source_query="SELECT * FROM data",
+                data_col="data",
+                timestamp_col="ts",
+                horizon=10,
+                conf_level=0.95,
+            )
+            assert len(results) == 1
+            assert results[0]["prediction"] == 42.0
+            mock_aforecast.assert_called_once_with(
+                "test_model",
+                "test_table",
+                "ts",
+                "data",
+                10,
+                "SELECT * FROM data",
+                0.95,
+            )
+
+    def test_forecast(self, engine):
+        """Test that forecast evaluates via _run_as_sync to proxy the google_ml.forecast."""
+        engine._run_as_sync.return_value = [{"prediction": 1.0}]
+        results = engine.forecast(
+            model_id="test_model",
+            source_table="test_table",
+            source_query=None,
+            data_col="data",
+            timestamp_col="ts",
+            horizon=5,
+        )
+        assert results == [{"prediction": 1.0}]
+        engine._run_as_sync.assert_called_once()
+
+    def test_forecast_with_optional_params(self, engine):
+        """Test forecast with source_query and conf_level."""
+        engine._run_as_sync.return_value = [{"prediction": 42.0}]
+        results = engine.forecast(
+            model_id="test_model",
+            source_table="test_table",
+            source_query="SELECT * FROM data",
+            data_col="data",
+            timestamp_col="ts",
+            horizon=10,
+            conf_level=0.95,
+        )
+        assert results == [{"prediction": 42.0}]
+        engine._run_as_sync.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_private_aforecast(self, engine):
+        """Test direct _aforecast execution and mapping parsing."""
+        with patch.object(engine._pool, "connect") as mock_connect:
+            mock_conn = AsyncMock()
+            mock_result = MagicMock()
+            mock_result.mappings.return_value = [
+                {"forecast_timestamp": "2026-08-07", "forecast_value": 100.0}
+            ]
+            mock_conn.execute.return_value = mock_result
+            mock_connect.return_value.__aenter__.return_value = mock_conn
+
+            results = await engine._aforecast(
+                model_id="model_1",
+                source_table="sales",
+                timestamp_col="date",
+                data_col="revenue",
+                horizon=3,
+                source_query="SELECT * FROM sales WHERE active = true",
+                conf_level=0.9,
+            )
+            assert len(results) == 1
+            assert results[0]["forecast_value"] == 100.0
+            call_args = mock_conn.execute.call_args
+            assert "SELECT * FROM google_ml.forecast" in str(call_args[0][0])
+            assert "source_query => :source_query" in str(call_args[0][0])
+            assert "conf_level => :conf_level" in str(call_args[0][0])
+            assert call_args[0][1] == {
+                "model_id": "model_1",
+                "source_table": "sales",
+                "timestamp_col": "date",
+                "data_col": "revenue",
+                "horizon": 3,
+                "source_query": "SELECT * FROM sales WHERE active = true",
+                "conf_level": 0.9,
+            }
+
+    @pytest.mark.asyncio
+    async def test_aforecast_validation_errors(self, engine):
+        """Test validation errors for invalid input parameters in _aforecast."""
+        with pytest.raises(ValueError, match="model_id must be provided"):
+            await engine._aforecast(
+                model_id="",
+                source_table="sales",
+                timestamp_col="date",
+                data_col="revenue",
+                horizon=3,
+            )
+        with pytest.raises(ValueError, match="source_table must be provided"):
+            await engine._aforecast(
+                model_id="model_1",
+                source_table="",
+                timestamp_col="date",
+                data_col="revenue",
+                horizon=3,
+            )
+        with pytest.raises(ValueError, match="timestamp_col must be provided"):
+            await engine._aforecast(
+                model_id="model_1",
+                source_table="sales",
+                timestamp_col="",
+                data_col="revenue",
+                horizon=3,
+            )
+        with pytest.raises(ValueError, match="data_col must be provided"):
+            await engine._aforecast(
+                model_id="model_1",
+                source_table="sales",
+                timestamp_col="date",
+                data_col="",
+                horizon=3,
+            )
+        with pytest.raises(ValueError, match="horizon must be a positive integer"):
+            await engine._aforecast(
+                model_id="model_1",
+                source_table="sales",
+                timestamp_col="date",
+                data_col="revenue",
+                horizon=0,
+            )
+        with pytest.raises(ValueError, match="conf_level must be between 0 and 1"):
+            await engine._aforecast(
+                model_id="model_1",
+                source_table="sales",
+                timestamp_col="date",
+                data_col="revenue",
+                horizon=3,
+                conf_level=1.5,
+            )

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import os
 import uuid
 from typing import Sequence
@@ -635,6 +636,10 @@ class TestEngineSync:
         for row in results:
             assert row in expected
 
+    @pytest.mark.skipif(
+        not os.environ.get("PROJECT_ID"),
+        reason="Requires live AlloyDB instance (PROJECT_ID not set)",
+    )
     async def test_live_forecast(self, engine):
         """Test live google_ml.forecast validation / execution on AlloyDB."""
         ts_table = "forecast_live_ts_" + str(uuid.uuid4()).replace("-", "_")
@@ -650,10 +655,10 @@ class TestEngineSync:
         try:
             results = await engine.aforecast(
                 model_id="test_model",
-                source_table=ts_table,
                 timestamp_col="timestamp_col",
                 data_col="data_col",
                 horizon=3,
+                source_table=ts_table,
             )
             assert isinstance(results, list)
         except Exception as e:
@@ -706,16 +711,16 @@ class TestEngineUnit:
 
             results = await engine.aforecast(
                 model_id="test_model",
-                source_table="test_table",
-                source_query=None,
-                data_col="data",
                 timestamp_col="ts",
+                data_col="data",
                 horizon=5,
+                source_table="test_table",
             )
             assert len(results) == 2
             assert results[0]["prediction"] == 1.0
             call_args = mock_conn.execute.call_args
             assert "SELECT * FROM google_ml.forecast" in str(call_args[0][0])
+            assert "source_table => :source_table" in str(call_args[0][0])
             assert "source_query" not in str(call_args[0][0])
             assert "conf_level" not in str(call_args[0][0])
             assert call_args[0][1] == {
@@ -727,30 +732,64 @@ class TestEngineUnit:
             }
 
     @pytest.mark.asyncio
+    async def test_aforecast_with_source_query(self, engine):
+        """Test aforecast with source_query only."""
+        with patch.object(engine._pool, "connect") as mock_connect:
+            mock_conn = AsyncMock()
+            mock_result = MagicMock()
+            mock_result.mappings.return_value = [
+                {"prediction": 1.0},
+                {"prediction": 2.0},
+            ]
+            mock_conn.execute.return_value = mock_result
+            mock_connect.return_value.__aenter__.return_value = mock_conn
+
+            results = await engine.aforecast(
+                model_id="test_model",
+                timestamp_col="ts",
+                data_col="data",
+                horizon=5,
+                source_query="SELECT * FROM test_table",
+            )
+            assert len(results) == 2
+            assert results[0]["prediction"] == 1.0
+            call_args = mock_conn.execute.call_args
+            assert "SELECT * FROM google_ml.forecast" in str(call_args[0][0])
+            assert "source_query => :source_query" in str(call_args[0][0])
+            assert "source_table" not in str(call_args[0][0])
+            assert "conf_level" not in str(call_args[0][0])
+            assert call_args[0][1] == {
+                "model_id": "test_model",
+                "source_query": "SELECT * FROM test_table",
+                "timestamp_col": "ts",
+                "data_col": "data",
+                "horizon": 5,
+            }
+
+    @pytest.mark.asyncio
     async def test_aforecast_with_optional_params(self, engine):
-        """Test aforecast with source_query and conf_level."""
+        """Test aforecast with optional conf_level."""
         with patch.object(
             engine, "_aforecast", new_callable=AsyncMock
         ) as mock_aforecast:
             mock_aforecast.return_value = [{"prediction": 42.0}]
             results = await engine.aforecast(
                 model_id="test_model",
-                source_table="test_table",
-                source_query="SELECT * FROM data",
-                data_col="data",
                 timestamp_col="ts",
+                data_col="data",
                 horizon=10,
+                source_table="test_table",
                 conf_level=0.95,
             )
             assert len(results) == 1
             assert results[0]["prediction"] == 42.0
             mock_aforecast.assert_called_once_with(
                 "test_model",
-                "test_table",
                 "ts",
                 "data",
                 10,
-                "SELECT * FROM data",
+                "test_table",
+                None,
                 0.95,
             )
 
@@ -759,29 +798,86 @@ class TestEngineUnit:
         engine._run_as_sync.return_value = [{"prediction": 1.0}]
         results = engine.forecast(
             model_id="test_model",
-            source_table="test_table",
-            source_query=None,
-            data_col="data",
             timestamp_col="ts",
+            data_col="data",
             horizon=5,
+            source_table="test_table",
         )
         assert results == [{"prediction": 1.0}]
         engine._run_as_sync.assert_called_once()
 
+    def test_forecast_with_source_query(self, engine):
+        """Test forecast with source_query only executes cleanly and generates correct SQL."""
+        with patch.object(engine._pool, "connect") as mock_connect:
+            mock_conn = AsyncMock()
+            mock_result = MagicMock()
+            mock_result.mappings.return_value = [{"prediction": 42.0}]
+            mock_conn.execute.return_value = mock_result
+            mock_connect.return_value.__aenter__.return_value = mock_conn
+
+            engine._run_as_sync.side_effect = lambda coro: asyncio.run(coro)
+            results = engine.forecast(
+                model_id="test_model",
+                timestamp_col="ts",
+                data_col="data",
+                horizon=10,
+                source_query="SELECT * FROM data",
+            )
+            assert results == [{"prediction": 42.0}]
+            call_args = mock_conn.execute.call_args
+            assert "SELECT * FROM google_ml.forecast" in str(call_args[0][0])
+            assert "source_query => :source_query" in str(call_args[0][0])
+            assert "source_table" not in str(call_args[0][0])
+            assert "conf_level" not in str(call_args[0][0])
+            assert call_args[0][1] == {
+                "model_id": "test_model",
+                "source_query": "SELECT * FROM data",
+                "timestamp_col": "ts",
+                "data_col": "data",
+                "horizon": 10,
+            }
+
     def test_forecast_with_optional_params(self, engine):
-        """Test forecast with source_query and conf_level."""
+        """Test forecast with optional conf_level."""
         engine._run_as_sync.return_value = [{"prediction": 42.0}]
         results = engine.forecast(
             model_id="test_model",
-            source_table="test_table",
-            source_query="SELECT * FROM data",
-            data_col="data",
             timestamp_col="ts",
+            data_col="data",
             horizon=10,
+            source_table="test_table",
             conf_level=0.95,
         )
         assert results == [{"prediction": 42.0}]
         engine._run_as_sync.assert_called_once()
+
+    def test_forecast_validation_errors(self, engine):
+        """Test validation errors for invalid input parameters in sync forecast."""
+        engine._run_as_sync.side_effect = lambda coro: asyncio.run(coro)
+        # Mutual exclusivity: neither provided
+        with pytest.raises(
+            ValueError,
+            match="Exactly one of 'source_table' or 'source_query' must be provided",
+        ):
+            engine.forecast(
+                model_id="model_1",
+                timestamp_col="date",
+                data_col="revenue",
+                horizon=3,
+            )
+        # Mutual exclusivity: both provided
+        with pytest.raises(
+            ValueError,
+            match="Exactly one of 'source_table' or 'source_query' must be provided",
+        ):
+            engine.forecast(
+                model_id="model_1",
+                timestamp_col="date",
+                data_col="revenue",
+                horizon=3,
+                source_table="sales",
+                source_query="SELECT * FROM sales",
+            )
 
     @pytest.mark.asyncio
     async def test_private_aforecast(self, engine):
@@ -797,18 +893,18 @@ class TestEngineUnit:
 
             results = await engine._aforecast(
                 model_id="model_1",
-                source_table="sales",
                 timestamp_col="date",
                 data_col="revenue",
                 horizon=3,
-                source_query="SELECT * FROM sales WHERE active = true",
+                source_table="sales",
                 conf_level=0.9,
             )
             assert len(results) == 1
             assert results[0]["forecast_value"] == 100.0
             call_args = mock_conn.execute.call_args
             assert "SELECT * FROM google_ml.forecast" in str(call_args[0][0])
-            assert "source_query => :source_query" in str(call_args[0][0])
+            assert "source_table => :source_table" in str(call_args[0][0])
+            assert "source_query" not in str(call_args[0][0])
             assert "conf_level => :conf_level" in str(call_args[0][0])
             assert call_args[0][1] == {
                 "model_id": "model_1",
@@ -816,63 +912,359 @@ class TestEngineUnit:
                 "timestamp_col": "date",
                 "data_col": "revenue",
                 "horizon": 3,
-                "source_query": "SELECT * FROM sales WHERE active = true",
                 "conf_level": 0.9,
             }
 
     @pytest.mark.asyncio
     async def test_aforecast_validation_errors(self, engine):
-        """Test validation errors for invalid input parameters in _aforecast."""
-        with pytest.raises(ValueError, match="model_id must be a non-empty string"):
+        """Test validation errors for invalid input parameters in aforecast and _aforecast."""
+        # Mutual exclusivity: neither provided (_aforecast)
+        with pytest.raises(
+            ValueError,
+            match="Exactly one of 'source_table' or 'source_query' must be provided",
+        ):
             await engine._aforecast(
-                model_id="",
-                source_table="sales",
+                model_id="model_1",
                 timestamp_col="date",
                 data_col="revenue",
                 horizon=3,
             )
-        with pytest.raises(ValueError, match="source_table must be a non-empty string"):
-            await engine._aforecast(
+        # Mutual exclusivity: neither provided (public aforecast)
+        with pytest.raises(
+            ValueError,
+            match="Exactly one of 'source_table' or 'source_query' must be provided",
+        ):
+            await engine.aforecast(
                 model_id="model_1",
-                source_table="",
                 timestamp_col="date",
                 data_col="revenue",
                 horizon=3,
+            )
+        # Mutual exclusivity: both provided (_aforecast)
+        with pytest.raises(
+            ValueError,
+            match="Exactly one of 'source_table' or 'source_query' must be provided",
+        ):
+            await engine._aforecast(
+                model_id="model_1",
+                timestamp_col="date",
+                data_col="revenue",
+                horizon=3,
+                source_table="sales",
+                source_query="SELECT * FROM sales",
+            )
+        # Mutual exclusivity: both provided (public aforecast)
+        with pytest.raises(
+            ValueError,
+            match="Exactly one of 'source_table' or 'source_query' must be provided",
+        ):
+            await engine.aforecast(
+                model_id="model_1",
+                timestamp_col="date",
+                data_col="revenue",
+                horizon=3,
+                source_table="sales",
+                source_query="SELECT * FROM sales",
+            )
+        with pytest.raises(ValueError, match="model_id must be a non-empty string"):
+            await engine._aforecast(
+                model_id="",
+                timestamp_col="date",
+                data_col="revenue",
+                horizon=3,
+                source_table="sales",
+            )
+        with pytest.raises(ValueError, match="source_table must be a non-empty string"):
+            await engine._aforecast(
+                model_id="model_1",
+                timestamp_col="date",
+                data_col="revenue",
+                horizon=3,
+                source_table="",
+            )
+        with pytest.raises(ValueError, match="source_table must be a non-empty string"):
+            await engine._aforecast(
+                model_id="model_1",
+                timestamp_col="date",
+                data_col="revenue",
+                horizon=3,
+                source_table="   ",
+            )
+        with pytest.raises(ValueError, match="source_table must be a non-empty string"):
+            await engine._aforecast(
+                model_id="model_1",
+                timestamp_col="date",
+                data_col="revenue",
+                horizon=3,
+                source_table=123,  # type: ignore
+            )
+        with pytest.raises(ValueError, match="source_query must be a non-empty string"):
+            await engine._aforecast(
+                model_id="model_1",
+                timestamp_col="date",
+                data_col="revenue",
+                horizon=3,
+                source_query="",
+            )
+        with pytest.raises(ValueError, match="source_query must be a non-empty string"):
+            await engine._aforecast(
+                model_id="model_1",
+                timestamp_col="date",
+                data_col="revenue",
+                horizon=3,
+                source_query="   ",
+            )
+        with pytest.raises(ValueError, match="source_query must be a non-empty string"):
+            await engine._aforecast(
+                model_id="model_1",
+                timestamp_col="date",
+                data_col="revenue",
+                horizon=3,
+                source_query=123,  # type: ignore
             )
         with pytest.raises(
             ValueError, match="timestamp_col must be a non-empty string"
         ):
             await engine._aforecast(
                 model_id="model_1",
-                source_table="sales",
                 timestamp_col="",
                 data_col="revenue",
                 horizon=3,
+                source_table="sales",
             )
         with pytest.raises(ValueError, match="data_col must be a non-empty string"):
             await engine._aforecast(
                 model_id="model_1",
-                source_table="sales",
                 timestamp_col="date",
                 data_col="",
                 horizon=3,
+                source_table="sales",
             )
         with pytest.raises(ValueError, match="horizon must be a positive integer"):
             await engine._aforecast(
                 model_id="model_1",
-                source_table="sales",
                 timestamp_col="date",
                 data_col="revenue",
                 horizon=0,
+                source_table="sales",
+            )
+        with pytest.raises(ValueError, match="horizon must be a positive integer"):
+            await engine._aforecast(
+                model_id="model_1",
+                timestamp_col="date",
+                data_col="revenue",
+                horizon=-5,
+                source_table="sales",
+            )
+        with pytest.raises(ValueError, match="horizon must be a positive integer"):
+            await engine._aforecast(
+                model_id="model_1",
+                timestamp_col="date",
+                data_col="revenue",
+                horizon=True,  # type: ignore
+                source_table="sales",
+            )
+        with pytest.raises(ValueError, match="horizon must be a positive integer"):
+            await engine._aforecast(
+                model_id="model_1",
+                timestamp_col="date",
+                data_col="revenue",
+                horizon=1.5,  # type: ignore
+                source_table="sales",
+            )
+        with pytest.raises(
+            ValueError, match="horizon exceeds maximum 32-bit integer limit"
+        ):
+            await engine._aforecast(
+                model_id="model_1",
+                timestamp_col="date",
+                data_col="revenue",
+                horizon=2_147_483_648,
+                source_table="sales",
             )
         with pytest.raises(
             ValueError, match="conf_level must be a float strictly between 0 and 1"
         ):
             await engine._aforecast(
                 model_id="model_1",
-                source_table="sales",
                 timestamp_col="date",
                 data_col="revenue",
                 horizon=3,
+                source_table="sales",
+                conf_level=0,
+            )
+        with pytest.raises(
+            ValueError, match="conf_level must be a float strictly between 0 and 1"
+        ):
+            await engine._aforecast(
+                model_id="model_1",
+                timestamp_col="date",
+                data_col="revenue",
+                horizon=3,
+                source_table="sales",
+                conf_level=1.0,
+            )
+        with pytest.raises(
+            ValueError, match="conf_level must be a float strictly between 0 and 1"
+        ):
+            await engine._aforecast(
+                model_id="model_1",
+                timestamp_col="date",
+                data_col="revenue",
+                horizon=3,
+                source_table="sales",
+                conf_level=-0.5,
+            )
+        with pytest.raises(
+            ValueError, match="conf_level must be a float strictly between 0 and 1"
+        ):
+            await engine._aforecast(
+                model_id="model_1",
+                timestamp_col="date",
+                data_col="revenue",
+                horizon=3,
+                source_table="sales",
                 conf_level=1.5,
             )
+        with pytest.raises(TypeError, match="conf_level must be a float"):
+            await engine._aforecast(
+                model_id="model_1",
+                timestamp_col="date",
+                data_col="revenue",
+                horizon=3,
+                source_table="sales",
+                conf_level=True,  # type: ignore
+            )
+
+    @pytest.mark.asyncio
+    async def test_aforecast_google_ml_integration_extension_error(self, engine):
+        """Test that _aforecast raises informative error when google_ml_integration extension is missing."""
+        from sqlalchemy.exc import ProgrammingError
+
+        expected_msg = (
+            "AlloyDB AI google_ml_integration extension is not installed or enabled. "
+            "Please execute 'CREATE EXTENSION IF NOT EXISTS google_ml_integration CASCADE;' on your database."
+        )
+
+        # Test error string containing "google_ml_integration"
+        with patch.object(engine._pool, "connect") as mock_connect:
+            mock_conn = AsyncMock()
+            mock_conn.execute.side_effect = Exception(
+                'extension "google_ml_integration" is not installed'
+            )
+            mock_connect.return_value.__aenter__.return_value = mock_conn
+
+            with pytest.raises(RuntimeError, match=expected_msg):
+                await engine._aforecast(
+                    model_id="model_1",
+                    timestamp_col="date",
+                    data_col="revenue",
+                    horizon=3,
+                    source_table="sales",
+                )
+
+        # Test error string containing "google_ml"
+        with patch.object(engine._pool, "connect") as mock_connect:
+            mock_conn = AsyncMock()
+            mock_conn.execute.side_effect = Exception(
+                'schema "google_ml" does not exist'
+            )
+            mock_connect.return_value.__aenter__.return_value = mock_conn
+
+            with pytest.raises(RuntimeError, match=expected_msg):
+                await engine._aforecast(
+                    model_id="model_1",
+                    timestamp_col="date",
+                    data_col="revenue",
+                    horizon=3,
+                    source_table="sales",
+                )
+
+        # Test UndefinedFunctionError direct
+        class UndefinedFunctionError(Exception):
+            pass
+
+        with patch.object(engine._pool, "connect") as mock_connect:
+            mock_conn = AsyncMock()
+            mock_conn.execute.side_effect = UndefinedFunctionError(
+                "function does not exist"
+            )
+            mock_connect.return_value.__aenter__.return_value = mock_conn
+
+            with pytest.raises(RuntimeError, match=expected_msg):
+                await engine._aforecast(
+                    model_id="model_1",
+                    timestamp_col="date",
+                    data_col="revenue",
+                    horizon=3,
+                    source_table="sales",
+                )
+
+        # Test UndefinedSchemaError direct
+        class UndefinedSchemaError(Exception):
+            pass
+
+        with patch.object(engine._pool, "connect") as mock_connect:
+            mock_conn = AsyncMock()
+            mock_conn.execute.side_effect = UndefinedSchemaError(
+                "schema does not exist"
+            )
+            mock_connect.return_value.__aenter__.return_value = mock_conn
+
+            with pytest.raises(RuntimeError, match=expected_msg):
+                await engine._aforecast(
+                    model_id="model_1",
+                    timestamp_col="date",
+                    data_col="revenue",
+                    horizon=3,
+                    source_table="sales",
+                )
+
+        # Test SQLAlchemy ProgrammingError wrapping UndefinedFunctionError
+        with patch.object(engine._pool, "connect") as mock_connect:
+            mock_conn = AsyncMock()
+            orig_err = UndefinedFunctionError("function does not exist")
+            wrapped_err = ProgrammingError("SELECT *", {}, orig_err)
+            mock_conn.execute.side_effect = wrapped_err
+            mock_connect.return_value.__aenter__.return_value = mock_conn
+
+            with pytest.raises(RuntimeError, match=expected_msg):
+                await engine._aforecast(
+                    model_id="model_1",
+                    timestamp_col="date",
+                    data_col="revenue",
+                    horizon=3,
+                    source_table="sales",
+                )
+
+        # Test SQLAlchemy ProgrammingError wrapping UndefinedSchemaError
+        with patch.object(engine._pool, "connect") as mock_connect:
+            mock_conn = AsyncMock()
+            orig_err = UndefinedSchemaError("schema does not exist")
+            wrapped_err = ProgrammingError("SELECT *", {}, orig_err)
+            mock_conn.execute.side_effect = wrapped_err
+            mock_connect.return_value.__aenter__.return_value = mock_conn
+
+            with pytest.raises(RuntimeError, match=expected_msg):
+                await engine._aforecast(
+                    model_id="model_1",
+                    timestamp_col="date",
+                    data_col="revenue",
+                    horizon=3,
+                    source_table="sales",
+                )
+
+        # Test unrelated error is re-raised
+        with patch.object(engine._pool, "connect") as mock_connect:
+            mock_conn = AsyncMock()
+            mock_conn.execute.side_effect = RuntimeError("Connection dropped")
+            mock_connect.return_value.__aenter__.return_value = mock_conn
+
+            with pytest.raises(RuntimeError, match="Connection dropped"):
+                await engine._aforecast(
+                    model_id="model_1",
+                    timestamp_col="date",
+                    data_col="revenue",
+                    horizon=3,
+                    source_table="sales",
+                )


### PR DESCRIPTION
feat: add AlloyDB time-series forecasting methods to AlloyDBEngine
- Add aforecast and forecast methods on AlloyDBEngine
- Add parameter validation for forecasting inputs
- Add dynamic SQL builder for google_ml.forecast
- Add unit tests covering validation errors and SQL generation