### PR TITLE
chore(ci): Pin Langgraph prebuilt module to a version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ test = [
     "black[jupyter]==26.5.1",
     "isort==8.0.1",
     "langgraph==1.2.2",
+    "langgraph-prebuilt==1.2.2",
     "mypy==2.1.0",
     "pytest-asyncio==1.4.0",
     "pytest==9.0.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ test = [
     "black[jupyter]==26.5.1",
     "isort==8.0.1",
     "langgraph==1.2.2",
-    "langgraph-prebuilt==1.2.2",
+    "langgraph-prebuilt==1.1.0",
     "mypy==2.1.0",
     "pytest-asyncio==1.4.0",
     "pytest==9.0.3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ google-cloud-storage==3.10.1
 numpy==2.4.6; python_version >= "3.11"
 numpy==2.2.6; python_version == "3.10"
 langgraph==1.2.2
+langgraph-prebuilt==1.2.2
 langchain-postgres==0.0.17

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ google-cloud-storage==3.10.1
 numpy==2.4.6; python_version >= "3.11"
 numpy==2.2.6; python_version == "3.10"
 langgraph==1.2.2
-langgraph-prebuilt==1.2.2
+langgraph-prebuilt==1.1.0
 langchain-postgres==0.0.17


### PR DESCRIPTION
Fixes failing tests from https://github.com/googleapis/langchain-google-alloydb-pg-python/issues/583
