### PR TITLE
fix(embeddings): prevent SQL injection in AlloyDBEmbeddings

### DIFF
--- a/src/langchain_google_alloydb_pg/embeddings.py
+++ b/src/langchain_google_alloydb_pg/embeddings.py
@@ -129,7 +129,9 @@ class AlloyDBEmbeddings(Embeddings):
         )
 
     def embed_query_inline(self, query: str) -> str:
-        return f"embedding('{self.model_id}', '{query}')::vector"
+        clean_query = query.replace("'", "''")
+        clean_model_id = self.model_id.replace("'", "''")
+        return f"embedding('{clean_model_id}', '{clean_query}')::vector"
 
     async def aembed_query(self, text: str) -> list[float]:
         """Asynchronous Embed query text.
@@ -163,9 +165,11 @@ class AlloyDBEmbeddings(Embeddings):
         Returns:
             list[float]: Embedding.
         """
-        query = f" SELECT embedding('{self.model_id}', '{query}')::vector "
+        stmt = text("SELECT embedding(:model_id, :query)::vector")
         async with self._engine._pool.connect() as conn:
-            result = await conn.execute(text(query))
+            result = await conn.execute(
+                stmt, {"model_id": self.model_id, "query": query}
+            )
             result_map = result.mappings()
             results = result_map.fetchall()
         return json.loads(results[0]["embedding"])

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -111,12 +111,38 @@ class TestAlloyDBEmbeddings:
             assert isinstance(embedding_field, float)
             assert -1 <= embedding_field <= 1
 
+    async def test_embed_query_sql_injection(self, embeddings):
+        malicious_query = "'); DROP TABLE users; --"
+        embedding = embeddings.embed_query(malicious_query)
+        assert isinstance(embedding, list)
+        assert len(embedding) > 0
+        for embedding_field in embedding:
+            assert isinstance(embedding_field, float)
+            assert -1 <= embedding_field <= 1
+
     async def test_embed_query_inline(self, embeddings, model_id):
         embedding_query = embeddings.embed_query_inline("test document")
         assert embedding_query == f"embedding('{model_id}', 'test document')::vector"
 
+    async def test_embed_query_inline_sql_injection(self, embeddings, model_id):
+        malicious_query = "'); DROP TABLE users; --"
+        embedding_query = embeddings.embed_query_inline(malicious_query)
+        assert (
+            embedding_query
+            == f"embedding('{model_id}', '''); DROP TABLE users; --')::vector"
+        )
+
     async def test_aembed_query(self, embeddings):
         embedding = await embeddings.aembed_query("test document")
+        assert isinstance(embedding, list)
+        assert len(embedding) > 0
+        for embedding_field in embedding:
+            assert isinstance(embedding_field, float)
+            assert -1 <= embedding_field <= 1
+
+    async def test_aembed_query_sql_injection(self, embeddings):
+        malicious_query = "'); DROP TABLE users; --"
+        embedding = await embeddings.aembed_query(malicious_query)
         assert isinstance(embedding, list)
         assert len(embedding) > 0
         for embedding_field in embedding:


### PR DESCRIPTION
### Description

Fixes a critical SQL injection vulnerability in `AlloyDBEmbeddings` where unescaped query text was directly interpolated into SQL statements using f-strings.

#### Problem & Vulnerability
In `AlloyDBEmbeddings.__aembed_query`, the input `query` text was interpolated directly into an f-string:
```python
query = f" SELECT embedding('{self.model_id}', '{query}')::vector "
await conn.execute(text(query))
```
When user-supplied text (such as search queries or chat messages passed to a vector store) contained single quotes or malicious SQL syntax (e.g. `'); DROP TABLE users; --`), this broke out of the SQL string literal, allowing arbitrary SQL execution against the AlloyDB database.

Similarly, in `AlloyDBEmbeddings.embed_query_inline`, `self.model_id` and `query` were interpolated without escaping quotes, which could lead to SQL injection when `embed_query_inline` was inlined into vectorstore `INSERT` or similarity search statements.

#### Solution
1. **Parameterized Query in `__aembed_query`**:
   - Replaced string formatting with SQLAlchemy parameter binding:
     ```python
     stmt = text("SELECT embedding(:model_id, :query)::vector")
     result = await conn.execute(
         stmt, {"model_id": self.model_id, "query": query}
     )
     ```
   - Values are bound out-of-band as protocol-level parameters (`$1, $2` in asyncpg), completely preventing SQL syntax injection.
2. **Escaped Single Quotes in `embed_query_inline`**:
   - Escaped single quotes (`query.replace("'", "''")` and `self.model_id.replace("'", "''")`) to safely escape SQL string literals in inline vector expressions.
3. **Tests**:
   - Added unit tests in `tests/test_embeddings.py` verifying that SQL injection payloads are safely handled by `embed_query`, `aembed_query`, and `embed_query_inline`.