### PR TITLE
feat(embeddings): add templatized inline embedding support and tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "google-cloud-storage>=2.18.2, <4.0.0",
     "numpy>=1.24.4, <3.0.0; python_version >= '3.11'",
     "numpy>=1.24.4, <=2.2.6; python_version == '3.10'",
-    "langchain-postgres>=0.0.16",
+    "langchain-postgres @ git+https://github.com/langchain-ai/langchain-postgres.git@templatize-inline-embedding",
     "langgraph-checkpoint>=4.0.0, <4.2.0",
     "aiohttp>=3.12.15, <4.0.0",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ google-cloud-storage==3.10.1
 numpy==2.4.6; python_version >= "3.11"
 numpy==2.2.6; python_version == "3.10"
 langgraph==1.2.2
-langchain-postgres==0.0.17
+langchain-postgres @ git+https://github.com/langchain-ai/langchain-postgres.git@templatize-inline-embedding

--- a/src/langchain_google_alloydb_pg/embeddings.py
+++ b/src/langchain_google_alloydb_pg/embeddings.py
@@ -128,6 +128,10 @@ class AlloyDBEmbeddings(Embeddings):
             "Embedding functions are not implemented. Use VertexAIEmbeddings interface instead."
         )
 
+    def embed_query_inline_template(self, param_name: str = ":content") -> str:
+        clean_model_id = self.model_id.replace("'", "''")
+        return f"embedding('{clean_model_id}', {param_name})::vector"
+
     def embed_query_inline(self, query: str) -> str:
         return f"embedding('{self.model_id}', '{query}')::vector"
 

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -115,6 +115,12 @@ class TestAlloyDBEmbeddings:
         embedding_query = embeddings.embed_query_inline("test document")
         assert embedding_query == f"embedding('{model_id}', 'test document')::vector"
 
+    async def test_embed_query_inline_template(self, embeddings, model_id):
+        embedding_query = embeddings.embed_query_inline_template(":content")
+        assert embedding_query == f"embedding('{model_id}', :content)::vector"
+        embedding_query_search = embeddings.embed_query_inline_template(":query_text")
+        assert embedding_query_search == f"embedding('{model_id}', :query_text)::vector"
+
     async def test_aembed_query(self, embeddings):
         embedding = await embeddings.aembed_query("test document")
         assert isinstance(embedding, list)

--- a/tests/test_vectorstore_embeddings.py
+++ b/tests/test_vectorstore_embeddings.py
@@ -63,6 +63,18 @@ async def aexecute(
     await engine._run_as_async(run(engine, query))
 
 
+async def afetch(
+    engine: AlloyDBEngine,
+    query: str,
+):
+    async def run(engine, query):
+        async with engine._pool.connect() as conn:
+            result = await conn.execute(text(query))
+            return result.fetchall()
+
+    return await engine._run_as_async(run(engine, query))
+
+
 @pytest.mark.asyncio(loop_scope="class")
 class TestVectorStoreEmbeddings:
     @pytest.fixture(scope="module")
@@ -186,6 +198,79 @@ class TestVectorStoreEmbeddings:
         assert results == [Document(page_content="foo", id=ids[0])]
         results = await vs.asimilarity_search("foo", k=1, filter={"content": "bar"})
         assert results == [Document(page_content="bar", id=ids[1])]
+
+    async def test_asimilarity_search_sql_injection(self, engine, vs):
+        temp_table = "temp_" + str(uuid.uuid4()).replace("-", "_")
+        await aexecute(engine, f"CREATE TABLE {temp_table} (id INT, val TEXT);")
+        await aexecute(engine, f"INSERT INTO {temp_table} VALUES (1, 'untouched');")
+        try:
+            # Attempt UPDATE SQL injection in similarity search
+            malicious_query = (
+                f"foo'); UPDATE {temp_table} SET val = 'hacked' WHERE id = 1; --"
+            )
+            results = await vs.asimilarity_search(malicious_query, k=1)
+            assert isinstance(results, list)
+            assert len(results) == 1
+
+            # Assert: verify in database that the temp table row was NOT updated
+            rows = await afetch(engine, f"SELECT val FROM {temp_table} WHERE id = 1;")
+            assert len(rows) == 1
+            assert rows[0][0] == "untouched"
+
+            # Attempt DROP TABLE SQL injection in similarity search
+            malicious_drop = f"foo'); DROP TABLE {temp_table}; --"
+            results = await vs.asimilarity_search(malicious_drop, k=1)
+            assert isinstance(results, list)
+
+            # Assert: verify in database that the temp table was NOT dropped
+            check_table = await afetch(
+                engine,
+                f"SELECT table_name FROM information_schema.tables WHERE table_name = '{temp_table}';",
+            )
+            assert len(check_table) == 1
+            assert check_table[0][0] == temp_table
+        finally:
+            await aexecute(engine, f"DROP TABLE IF EXISTS {temp_table};")
+
+    async def test_aadd_texts_sql_injection(self, engine, vs):
+        temp_table = "temp_" + str(uuid.uuid4()).replace("-", "_")
+        await aexecute(engine, f"CREATE TABLE {temp_table} (id INT, val TEXT);")
+        await aexecute(engine, f"INSERT INTO {temp_table} VALUES (1, 'untouched');")
+        try:
+            # Attempt UPDATE SQL injection during document insertion
+            malicious_text = (
+                f"test'); UPDATE {temp_table} SET val = 'hacked' WHERE id = 1; --"
+            )
+            added_ids = await vs.aadd_texts([malicious_text])
+            assert len(added_ids) == 1
+
+            # Assert: verify in database that the temp table row was NOT updated
+            rows = await afetch(engine, f"SELECT val FROM {temp_table} WHERE id = 1;")
+            assert len(rows) == 1
+            assert rows[0][0] == "untouched"
+
+            # Assert: verify the exact string was stored as literal text in the vectorstore table
+            stored = await afetch(
+                engine,
+                f"SELECT content FROM {DEFAULT_TABLE} WHERE langchain_id = '{added_ids[0]}';",
+            )
+            assert len(stored) == 1
+            assert stored[0][0] == malicious_text
+
+            # Attempt DROP TABLE SQL injection during document insertion
+            malicious_drop = f"test2'); DROP TABLE {temp_table}; --"
+            drop_ids = await vs.aadd_texts([malicious_drop])
+            assert len(drop_ids) == 1
+
+            # Assert: verify in database that the temp table was NOT dropped
+            check_table = await afetch(
+                engine,
+                f"SELECT table_name FROM information_schema.tables WHERE table_name = '{temp_table}';",
+            )
+            assert len(check_table) == 1
+            assert check_table[0][0] == temp_table
+        finally:
+            await aexecute(engine, f"DROP TABLE IF EXISTS {temp_table};")
 
     async def test_asimilarity_search_score(self, vs):
         results = await vs.asimilarity_search_with_score("foo")

--- a/tests/test_vectorstore_embeddings.py
+++ b/tests/test_vectorstore_embeddings.py
@@ -14,6 +14,7 @@
 
 import os
 import uuid
+from typing import Any, Sequence
 
 import pytest
 import pytest_asyncio
@@ -66,7 +67,7 @@ async def aexecute(
 async def afetch(
     engine: AlloyDBEngine,
     query: str,
-):
+) -> Sequence[Any]:
     async def run(engine, query):
         async with engine._pool.connect() as conn:
             result = await conn.execute(text(query))


### PR DESCRIPTION
feat(embeddings): add templatized inline embedding support and tests
- Add embed_query_inline_template to AlloyDBEmbeddings returning parameterized SQL template
- Add unit test for embed_query_inline_template in test_embeddings.py
- Add regression tests with temp table assertions in test_vectorstore_embeddings.py
