### PR TITLE
feat: implement AlloyDBDocumentCompressor using google_ml.rank

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,7 @@ API Reference
   langchain_google_alloydb_pg/vectorstore
   langchain_google_alloydb_pg/loader
   langchain_google_alloydb_pg/history
+  langchain_google_alloydb_pg/document_compressor
 
 How to Choose a Nearest-Neighbor Index Guide
 --------------------------------------------

--- a/docs/langchain_google_alloydb_pg/document_compressor.rst
+++ b/docs/langchain_google_alloydb_pg/document_compressor.rst
@@ -1,0 +1,7 @@
+Document Compressor
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: langchain_google_alloydb_pg.document_compressor
+  :members:
+  :private-members:
+  :noindex:

--- a/src/langchain_google_alloydb_pg/__init__.py
+++ b/src/langchain_google_alloydb_pg/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ from langchain_postgres.v2.hybrid_search_config import (
 
 from .chat_message_history import AlloyDBChatMessageHistory
 from .checkpoint import AlloyDBSaver
+from .document_compressor import AlloyDBDocumentCompressor
 from .embeddings import AlloyDBEmbeddings
 from .engine import AlloyDBEngine
 from .loader import AlloyDBDocumentSaver, AlloyDBLoader
@@ -29,16 +30,17 @@ from .vectorstore import AlloyDBVectorStore
 from .version import __version__
 
 __all__ = [
-    "AlloyDBEngine",
-    "Column",
-    "AlloyDBVectorStore",
-    "AlloyDBLoader",
-    "AlloyDBDocumentSaver",
     "AlloyDBChatMessageHistory",
+    "AlloyDBDocumentCompressor",
+    "AlloyDBDocumentSaver",
     "AlloyDBEmbeddings",
-    "AlloyDBModelManager",
+    "AlloyDBEngine",
+    "AlloyDBLoader",
     "AlloyDBModel",
+    "AlloyDBModelManager",
     "AlloyDBSaver",
+    "AlloyDBVectorStore",
+    "Column",
     "HybridSearchConfig",
     "reciprocal_rank_fusion",
     "weighted_sum_ranking",

--- a/src/langchain_google_alloydb_pg/document_compressor.py
+++ b/src/langchain_google_alloydb_pg/document_compressor.py
@@ -38,7 +38,7 @@ class AlloyDBDocumentCompressor(BaseDocumentCompressor):
     model_id: str = "semantic-ranker-512@latest"
     top_n: Optional[int] = None
 
-    if ConfigDict is not None:
+    if hasattr(BaseDocumentCompressor, "model_config") and ConfigDict is not None:
         model_config = ConfigDict(arbitrary_types_allowed=True)
     else:
 
@@ -66,65 +66,85 @@ class AlloyDBDocumentCompressor(BaseDocumentCompressor):
         if not documents:
             return []
 
+        if not query or not query.strip():
+            raise ValueError("Query string cannot be empty or whitespace.")
+
+        if self.top_n is not None and self.top_n <= 0:
+            raise ValueError("top_n must be a positive integer greater than 0.")
+
         texts = [doc.page_content for doc in documents]
 
-        # We construct a parameterized query that calls google_ml.rank
-        # The return type depends on the exact function signature, but typically it returns rows
-        # with an index or id mapping back to the input array.
-        # We query the function and rely on the order it returns to sort the documents.
+        # Parameterized query calling google_ml.rank
         query_text = """
             SELECT * FROM google_ml.rank(:model_id, :query, :documents, :top_n)
         """
 
-        async with self.engine._pool.connect() as conn:
-            result = await conn.execute(
-                text(query_text),
-                {
-                    "model_id": self.model_id,
-                    "query": query,
-                    "documents": texts,
-                    "top_n": self.top_n if self.top_n is not None else len(documents),
-                },
-            )
-            rows = result.fetchall()
+        async def _query():
+            async with self.engine._pool.connect() as conn:
+                result = await conn.execute(
+                    text(query_text),
+                    {
+                        "model_id": self.model_id,
+                        "query": query,
+                        "documents": texts,
+                        "top_n": (
+                            self.top_n if self.top_n is not None else len(documents)
+                        ),
+                    },
+                )
+                return result.fetchall()
+
+        rows = await self.engine._run_as_async(_query())
 
         compressed_docs = []
-        # Fallback to standard 1-to-1 if returns raw scores array
+        # Support fallback to array of scores if returned by custom transforms
         if len(rows) > 0 and len(rows[0]) == 1 and isinstance(rows[0][0], list):
-            # It returned a single row with an array of scores
             scores = rows[0][0]
             for idx, score in enumerate(scores):
                 if idx >= len(documents):
                     break
-                doc = documents[idx]
-                doc.metadata["relevance_score"] = float(score)
-                compressed_docs.append(doc)
-            # Sort by score descending
+                if score is None:
+                    continue
+                orig_doc = documents[idx]
+                new_metadata = dict(orig_doc.metadata)
+                new_metadata["relevance_score"] = float(score)
+                compressed_docs.append(
+                    Document(page_content=orig_doc.page_content, metadata=new_metadata)
+                )
             compressed_docs.sort(
                 key=lambda x: x.metadata["relevance_score"], reverse=True
             )
-            if self.top_n:
+            if self.top_n is not None:
                 compressed_docs = compressed_docs[: self.top_n]
         else:
-            # It returned rows, hopefully with (index, score) or just scores
-            for idx, row in enumerate(rows):
+            # Table-valued return: TABLE(index integer, score real)
+            for row in rows:
                 if len(row) >= 2:
-                    # Assuming (index, score) or (id, score)
-                    # We will just map it positionally for now or try to extract index
                     try:
-                        doc_idx = int(row[0]) - 1  # Postgres arrays are 1-indexed
-                        doc = documents[doc_idx]
-                        doc.metadata["relevance_score"] = float(row[1])
+                        raw_idx, raw_score = row[0], row[1]
+                        if raw_score is None:
+                            continue
+                        raw_idx_int = int(raw_idx)
+                        if raw_idx_int < 1 or raw_idx_int > len(documents):
+                            raise IndexError(
+                                f"Index {raw_idx_int} out of 1-based bounds [1, {len(documents)}]"
+                            )
+                        doc_idx = raw_idx_int - 1
+                        orig_doc = documents[doc_idx]
+                        score = float(raw_score)
+                        new_metadata = dict(orig_doc.metadata)
+                        new_metadata["relevance_score"] = score
+                        compressed_docs.append(
+                            Document(
+                                page_content=orig_doc.page_content,
+                                metadata=new_metadata,
+                            )
+                        )
                     except (ValueError, TypeError, IndexError):
-                        doc = documents[idx]
-                        try:
-                            doc.metadata["relevance_score"] = float(row[1])
-                        except (ValueError, TypeError, IndexError):
-                            doc.metadata["relevance_score"] = float(row[0])
+                        continue
                 else:
-                    doc = documents[idx]
-                    doc.metadata["relevance_score"] = float(row[0])
-                compressed_docs.append(doc)
+                    # Single column returns without document index cannot be safely mapped
+                    continue
 
         if self.top_n is not None:
             compressed_docs = compressed_docs[: self.top_n]

--- a/src/langchain_google_alloydb_pg/document_compressor.py
+++ b/src/langchain_google_alloydb_pg/document_compressor.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 from typing import Optional, Sequence
 
 from langchain_core.callbacks.manager import Callbacks
@@ -52,6 +53,20 @@ class AlloyDBDocumentCompressor(BaseDocumentCompressor):
         callbacks: Optional[Callbacks] = None,
     ) -> Sequence[Document]:
         """Compress documents using AlloyDB's rank model."""
+        try:
+            curr_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            curr_loop = None
+
+        if (
+            curr_loop is not None
+            and getattr(self.engine, "_loop", None) is not None
+            and curr_loop == self.engine._loop
+        ):
+            raise RuntimeError(
+                "Cannot call synchronous 'compress_documents' from the engine's background event loop "
+                "as it causes a thread deadlock. Use 'acompress_documents' instead."
+            )
         return self.engine._run_as_sync(
             self.acompress_documents(documents, query, callbacks)
         )
@@ -107,7 +122,11 @@ class AlloyDBDocumentCompressor(BaseDocumentCompressor):
                     continue
                 orig_doc = documents[idx]
                 new_metadata = dict(orig_doc.metadata)
-                new_metadata["relevance_score"] = float(score)
+                try:
+                    score_float = float(score)
+                except (ValueError, TypeError, OverflowError):
+                    continue
+                new_metadata["relevance_score"] = score_float
                 compressed_docs.append(
                     Document(page_content=orig_doc.page_content, metadata=new_metadata)
                 )
@@ -123,6 +142,8 @@ class AlloyDBDocumentCompressor(BaseDocumentCompressor):
                     try:
                         raw_idx, raw_score = row[0], row[1]
                         if raw_score is None:
+                            continue
+                        if isinstance(raw_idx, float) and not raw_idx.is_integer():
                             continue
                         raw_idx_int = int(raw_idx)
                         if raw_idx_int < 1 or raw_idx_int > len(documents):
@@ -140,7 +161,7 @@ class AlloyDBDocumentCompressor(BaseDocumentCompressor):
                                 metadata=new_metadata,
                             )
                         )
-                    except (ValueError, TypeError, IndexError):
+                    except (ValueError, TypeError, IndexError, OverflowError):
                         continue
                 else:
                     # Single column returns without document index cannot be safely mapped

--- a/src/langchain_google_alloydb_pg/document_compressor.py
+++ b/src/langchain_google_alloydb_pg/document_compressor.py
@@ -1,0 +1,132 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional, Sequence
+
+from langchain_core.callbacks.manager import Callbacks
+from langchain_core.documents import Document
+from langchain_core.documents.compressor import BaseDocumentCompressor
+from sqlalchemy import text
+
+try:
+    from pydantic import ConfigDict
+except ImportError:
+    ConfigDict = None  # type: ignore[assignment,misc]
+
+from .engine import AlloyDBEngine
+
+
+class AlloyDBDocumentCompressor(BaseDocumentCompressor):
+    """Document Compressor that uses AlloyDB's google_ml.rank() for reranking.
+
+    This class leverages AlloyDB's native Vertex AI ranking integration to rerank documents
+    based on a query directly in the database.
+    """
+
+    engine: AlloyDBEngine
+    model_id: str = "semantic-ranker-512@latest"
+    top_n: Optional[int] = None
+
+    if ConfigDict is not None:
+        model_config = ConfigDict(arbitrary_types_allowed=True)
+    else:
+
+        class Config:
+            arbitrary_types_allowed = True
+
+    def compress_documents(
+        self,
+        documents: Sequence[Document],
+        query: str,
+        callbacks: Optional[Callbacks] = None,
+    ) -> Sequence[Document]:
+        """Compress documents using AlloyDB's rank model."""
+        return self.engine._run_as_sync(
+            self.acompress_documents(documents, query, callbacks)
+        )
+
+    async def acompress_documents(
+        self,
+        documents: Sequence[Document],
+        query: str,
+        callbacks: Optional[Callbacks] = None,
+    ) -> Sequence[Document]:
+        """Asynchronously compress documents using AlloyDB's rank model."""
+        if not documents:
+            return []
+
+        texts = [doc.page_content for doc in documents]
+
+        # We construct a parameterized query that calls google_ml.rank
+        # The return type depends on the exact function signature, but typically it returns rows
+        # with an index or id mapping back to the input array.
+        # We query the function and rely on the order it returns to sort the documents.
+        query_text = """
+            SELECT * FROM google_ml.rank(:model_id, :query, :documents, :top_n)
+        """
+
+        async with self.engine._pool.connect() as conn:
+            result = await conn.execute(
+                text(query_text),
+                {
+                    "model_id": self.model_id,
+                    "query": query,
+                    "documents": texts,
+                    "top_n": self.top_n if self.top_n is not None else len(documents),
+                },
+            )
+            rows = result.fetchall()
+
+        compressed_docs = []
+        # Fallback to standard 1-to-1 if returns raw scores array
+        if len(rows) > 0 and len(rows[0]) == 1 and isinstance(rows[0][0], list):
+            # It returned a single row with an array of scores
+            scores = rows[0][0]
+            for idx, score in enumerate(scores):
+                if idx >= len(documents):
+                    break
+                doc = documents[idx]
+                doc.metadata["relevance_score"] = float(score)
+                compressed_docs.append(doc)
+            # Sort by score descending
+            compressed_docs.sort(
+                key=lambda x: x.metadata["relevance_score"], reverse=True
+            )
+            if self.top_n:
+                compressed_docs = compressed_docs[: self.top_n]
+        else:
+            # It returned rows, hopefully with (index, score) or just scores
+            for idx, row in enumerate(rows):
+                if len(row) >= 2:
+                    # Assuming (index, score) or (id, score)
+                    # We will just map it positionally for now or try to extract index
+                    try:
+                        doc_idx = int(row[0]) - 1  # Postgres arrays are 1-indexed
+                        doc = documents[doc_idx]
+                        doc.metadata["relevance_score"] = float(row[1])
+                    except (ValueError, TypeError, IndexError):
+                        doc = documents[idx]
+                        try:
+                            doc.metadata["relevance_score"] = float(row[1])
+                        except (ValueError, TypeError, IndexError):
+                            doc.metadata["relevance_score"] = float(row[0])
+                else:
+                    doc = documents[idx]
+                    doc.metadata["relevance_score"] = float(row[0])
+                compressed_docs.append(doc)
+
+        if self.top_n is not None:
+            compressed_docs = compressed_docs[: self.top_n]
+
+        return compressed_docs

--- a/tests/test_document_compressor.py
+++ b/tests/test_document_compressor.py
@@ -412,3 +412,82 @@ async def test_compress_documents_cross_loop_event_loop_safety():
         engine_loop.call_soon_threadsafe(engine_loop.stop)
         thread.join(timeout=2.0)
         engine_loop.close()
+
+
+@pytest.mark.asyncio
+async def test_compress_documents_infinity_index_overflow_handling(
+    mock_engine, sample_documents
+):
+    """Verify that float('inf') or float('-inf') index rows are safely skipped without OverflowError (NEW-641-01)."""
+    conn = mock_engine._pool.connect.return_value.__aenter__.return_value
+    conn.execute.return_value.fetchall.return_value = [
+        [float("inf"), 0.99],
+        [float("-inf"), 0.88],
+        [1, 0.95],
+    ]
+    compressor = AlloyDBDocumentCompressor(engine=mock_engine)
+    result = await compressor.acompress_documents(sample_documents, "query")
+    assert len(result) == 1
+    assert result[0].page_content == sample_documents[0].page_content
+    assert result[0].metadata["relevance_score"] == 0.95
+
+
+@pytest.mark.asyncio
+async def test_compress_documents_array_fallback_non_numeric_score(
+    mock_engine, sample_documents
+):
+    """Verify that non-numeric scores in array fallback are safely skipped without ValueError (NEW-641-02)."""
+    conn = mock_engine._pool.connect.return_value.__aenter__.return_value
+    conn.execute.return_value.fetchall.return_value = [
+        [["not_a_number", 0.85, "nan_val"]]
+    ]
+    compressor = AlloyDBDocumentCompressor(engine=mock_engine)
+    result = await compressor.acompress_documents(sample_documents, "query")
+    assert len(result) == 1
+    assert result[0].page_content == sample_documents[1].page_content
+    assert result[0].metadata["relevance_score"] == 0.85
+
+
+@pytest.mark.asyncio
+async def test_compress_documents_fractional_float_index_rejected(
+    mock_engine, sample_documents
+):
+    """Verify that fractional float indices (e.g. 1.5) are safely skipped rather than truncated (NEW-641-03)."""
+    conn = mock_engine._pool.connect.return_value.__aenter__.return_value
+    conn.execute.return_value.fetchall.return_value = [
+        [1.5, 0.99],
+        [2.7, 0.88],
+        [1.0, 0.95],  # 1.0 is an exact integer float, should be accepted
+    ]
+    compressor = AlloyDBDocumentCompressor(engine=mock_engine)
+    result = await compressor.acompress_documents(sample_documents, "query")
+    assert len(result) == 1
+    assert result[0].page_content == sample_documents[0].page_content
+    assert result[0].metadata["relevance_score"] == 0.95
+
+
+def test_compress_documents_sync_deadlock_on_engine_loop():
+    """Verify that calling compress_documents on the engine loop raises RuntimeError (NEW-641-04)."""
+    loop = asyncio.new_event_loop()
+
+    class DeadlockEngine(AlloyDBEngine):
+
+        def __init__(self, loop):
+            self._loop = loop
+
+    engine = DeadlockEngine(loop)
+    compressor = AlloyDBDocumentCompressor(engine=engine)
+
+    def run_on_loop():
+        with pytest.raises(
+            RuntimeError, match="Cannot call synchronous 'compress_documents'"
+        ):
+            compressor.compress_documents([Document(page_content="text")], "query")
+
+    async def runner():
+        run_on_loop()
+
+    try:
+        loop.run_until_complete(runner())
+    finally:
+        loop.close()

--- a/tests/test_document_compressor.py
+++ b/tests/test_document_compressor.py
@@ -411,3 +411,4 @@ async def test_compress_documents_cross_loop_event_loop_safety():
     finally:
         engine_loop.call_soon_threadsafe(engine_loop.stop)
         thread.join(timeout=2.0)
+        engine_loop.close()

--- a/tests/test_document_compressor.py
+++ b/tests/test_document_compressor.py
@@ -1,0 +1,187 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.documents import Document
+
+from langchain_google_alloydb_pg.document_compressor import (
+    AlloyDBDocumentCompressor,
+)
+from langchain_google_alloydb_pg.engine import AlloyDBEngine
+
+
+@pytest.fixture
+def mock_engine():
+    """Fixture providing a mocked AlloyDBEngine with async pool context."""
+
+    class DummyEngine(AlloyDBEngine):
+        def __init__(self):
+            pass
+
+        _pool = MagicMock()
+        _run_as_sync = MagicMock()
+
+    engine = DummyEngine()
+    engine._pool = MagicMock()
+    return engine
+
+
+@pytest.fixture
+def mock_documents():
+    """Fixture providing sample test documents."""
+    return [
+        Document(page_content="The quick brown fox."),
+        Document(page_content="Jumps over the lazy dog."),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_compressor_arun_score_per_row(mock_engine, mock_documents):
+    """Test async document compression with single-score row returns from google_ml.rank."""
+    conn_mock = mock_engine._pool.connect.return_value.__aenter__.return_value
+    exec_result = MagicMock()
+    exec_result.fetchall.return_value = [[0.9], [0.1]]
+    conn_mock.execute.return_value = exec_result
+
+    compressor = AlloyDBDocumentCompressor(
+        engine=mock_engine,
+        model_id="semantic-ranker-512@latest",
+        top_n=2,
+    )
+    result = await compressor.acompress_documents(mock_documents, "query about a fox")
+
+    assert len(result) == 2
+    assert result[0].page_content == "The quick brown fox."
+    assert result[0].metadata["relevance_score"] == 0.9
+    assert result[1].page_content == "Jumps over the lazy dog."
+    assert result[1].metadata["relevance_score"] == 0.1
+
+    # Verify parameterized SQL execution and query text
+    executed_query = conn_mock.execute.call_args[0][0].text
+    assert "SELECT * FROM google_ml.rank" in executed_query
+    executed_params = conn_mock.execute.call_args[0][1]
+    assert executed_params["model_id"] == "semantic-ranker-512@latest"
+    assert executed_params["query"] == "query about a fox"
+    assert executed_params["documents"] == [
+        "The quick brown fox.",
+        "Jumps over the lazy dog.",
+    ]
+    assert executed_params["top_n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_compressor_arun_table_indexed_reranking(mock_engine):
+    """Test async document compression with 1-based (index, score) table response."""
+    docs = [
+        Document(page_content="Document 1 - lower relevance."),
+        Document(page_content="Document 2 - higher relevance."),
+        Document(page_content="Document 3 - medium relevance."),
+    ]
+    conn_mock = mock_engine._pool.connect.return_value.__aenter__.return_value
+    exec_result = MagicMock()
+    # AlloyDB google_ml.rank returns TABLE(index integer, score real), 1-indexed
+    exec_result.fetchall.return_value = [[2, 0.95], [3, 0.70], [1, 0.30]]
+    conn_mock.execute.return_value = exec_result
+
+    compressor = AlloyDBDocumentCompressor(
+        engine=mock_engine,
+        top_n=2,
+    )
+    result = await compressor.acompress_documents(docs, "find relevant docs")
+
+    assert len(result) == 2
+    # First returned should be Document 2 (index 2 in Postgres -> index 1 in Python)
+    assert result[0].page_content == "Document 2 - higher relevance."
+    assert result[0].metadata["relevance_score"] == 0.95
+    # Second returned should be Document 3 (index 3 in Postgres -> index 2 in Python)
+    assert result[1].page_content == "Document 3 - medium relevance."
+    assert result[1].metadata["relevance_score"] == 0.70
+
+
+@pytest.mark.asyncio
+async def test_compressor_arun_array_of_scores(mock_engine, mock_documents):
+    """Test async document compression with single row returning score array."""
+    conn_mock = mock_engine._pool.connect.return_value.__aenter__.return_value
+    exec_result = MagicMock()
+    # Single row containing array of scores: [score_for_doc_0, score_for_doc_1]
+    exec_result.fetchall.return_value = [[[0.2, 0.85]]]
+    conn_mock.execute.return_value = exec_result
+
+    compressor = AlloyDBDocumentCompressor(
+        engine=mock_engine,
+        top_n=1,
+    )
+    result = await compressor.acompress_documents(mock_documents, "query")
+
+    assert len(result) == 1
+    # Sorted descending by score, so doc 1 (score 0.85) should be first
+    assert result[0].page_content == "Jumps over the lazy dog."
+    assert result[0].metadata["relevance_score"] == 0.85
+
+
+@pytest.mark.asyncio
+async def test_compressor_arun_empty_documents(mock_engine):
+    """Test that passing an empty document sequence short-circuits without DB query."""
+    compressor = AlloyDBDocumentCompressor(engine=mock_engine)
+    result = await compressor.acompress_documents([], "query")
+    assert result == []
+    assert not mock_engine._pool.connect.called
+
+
+@pytest.mark.asyncio
+async def test_compressor_arun_index_error_fallback(mock_engine, mock_documents):
+    """Test fallback when row tuple index is unparseable or out of bounds."""
+    conn_mock = mock_engine._pool.connect.return_value.__aenter__.return_value
+    exec_result = MagicMock()
+    # Invalid index string "invalid_idx" triggers ValueError/IndexError fallback
+    exec_result.fetchall.return_value = [["invalid_idx", 0.75], [999, 0.25]]
+    conn_mock.execute.return_value = exec_result
+
+    compressor = AlloyDBDocumentCompressor(engine=mock_engine)
+    result = await compressor.acompress_documents(mock_documents, "query")
+
+    assert len(result) == 2
+    assert result[0].page_content == "The quick brown fox."
+    assert result[1].page_content == "Jumps over the lazy dog."
+
+
+def test_compressor_run_sync(mock_engine, mock_documents):
+    """Test synchronous compress_documents delegates to _run_as_sync with 0 warnings."""
+    compressor = AlloyDBDocumentCompressor(engine=mock_engine)
+    mock_docs_ranked = [
+        Document(
+            page_content="The quick brown fox.",
+            metadata={"relevance_score": 0.9},
+        ),
+    ]
+
+    def mock_run_sync(coro):
+        # Explicitly close the unawaited coroutine in mock side effect to prevent RuntimeWarning
+        coro.close()
+        return mock_docs_ranked
+
+    with patch.object(mock_engine, "_run_as_sync", side_effect=mock_run_sync):
+        result = compressor.compress_documents(mock_documents, "query about a fox")
+        assert len(result) == 1
+        assert result[0].page_content == "The quick brown fox."
+        assert result[0].metadata["relevance_score"] == 0.9
+
+
+def test_compressor_default_attributes(mock_engine):
+    """Test default values of model_id and top_n."""
+    compressor = AlloyDBDocumentCompressor(engine=mock_engine)
+    assert compressor.model_id == "semantic-ranker-512@latest"
+    assert compressor.top_n is None

--- a/tests/test_document_compressor.py
+++ b/tests/test_document_compressor.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest.mock import MagicMock, patch
+import asyncio
+import threading
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from langchain_core.documents import Document
@@ -25,159 +27,55 @@ from langchain_google_alloydb_pg.engine import AlloyDBEngine
 
 @pytest.fixture
 def mock_engine():
-    """Fixture providing a mocked AlloyDBEngine with async pool context."""
+    """Fixture providing a mock AlloyDBEngine with pool and sync/async runners."""
 
     class DummyEngine(AlloyDBEngine):
+
         def __init__(self):
             pass
 
-        _pool = MagicMock()
-        _run_as_sync = MagicMock()
-
     engine = DummyEngine()
-    engine._pool = MagicMock()
+    pool_mock = MagicMock()
+    conn_mock = AsyncMock()
+    exec_result = MagicMock()
+    exec_result.fetchall.return_value = [[1, 0.95]]
+    conn_mock.execute.return_value = exec_result
+    pool_mock.connect.return_value.__aenter__.return_value = conn_mock
+    engine._pool = pool_mock
+
+    async def _real_async_runner(coro):
+        return await coro
+
+    engine._run_as_async = MagicMock(side_effect=_real_async_runner)
+
+    def _real_sync_runner(coro):
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+
+    engine._run_as_sync = MagicMock(side_effect=_real_sync_runner)
     return engine
 
 
 @pytest.fixture
-def mock_documents():
-    """Fixture providing sample test documents."""
+def sample_documents():
+    """Fixture providing a set of test documents."""
     return [
-        Document(page_content="The quick brown fox."),
-        Document(page_content="Jumps over the lazy dog."),
-    ]
-
-
-@pytest.mark.asyncio
-async def test_compressor_arun_score_per_row(mock_engine, mock_documents):
-    """Test async document compression with single-score row returns from google_ml.rank."""
-    conn_mock = mock_engine._pool.connect.return_value.__aenter__.return_value
-    exec_result = MagicMock()
-    exec_result.fetchall.return_value = [[0.9], [0.1]]
-    conn_mock.execute.return_value = exec_result
-
-    compressor = AlloyDBDocumentCompressor(
-        engine=mock_engine,
-        model_id="semantic-ranker-512@latest",
-        top_n=2,
-    )
-    result = await compressor.acompress_documents(mock_documents, "query about a fox")
-
-    assert len(result) == 2
-    assert result[0].page_content == "The quick brown fox."
-    assert result[0].metadata["relevance_score"] == 0.9
-    assert result[1].page_content == "Jumps over the lazy dog."
-    assert result[1].metadata["relevance_score"] == 0.1
-
-    # Verify parameterized SQL execution and query text
-    executed_query = conn_mock.execute.call_args[0][0].text
-    assert "SELECT * FROM google_ml.rank" in executed_query
-    executed_params = conn_mock.execute.call_args[0][1]
-    assert executed_params["model_id"] == "semantic-ranker-512@latest"
-    assert executed_params["query"] == "query about a fox"
-    assert executed_params["documents"] == [
-        "The quick brown fox.",
-        "Jumps over the lazy dog.",
-    ]
-    assert executed_params["top_n"] == 2
-
-
-@pytest.mark.asyncio
-async def test_compressor_arun_table_indexed_reranking(mock_engine):
-    """Test async document compression with 1-based (index, score) table response."""
-    docs = [
-        Document(page_content="Document 1 - lower relevance."),
-        Document(page_content="Document 2 - higher relevance."),
-        Document(page_content="Document 3 - medium relevance."),
-    ]
-    conn_mock = mock_engine._pool.connect.return_value.__aenter__.return_value
-    exec_result = MagicMock()
-    # AlloyDB google_ml.rank returns TABLE(index integer, score real), 1-indexed
-    exec_result.fetchall.return_value = [[2, 0.95], [3, 0.70], [1, 0.30]]
-    conn_mock.execute.return_value = exec_result
-
-    compressor = AlloyDBDocumentCompressor(
-        engine=mock_engine,
-        top_n=2,
-    )
-    result = await compressor.acompress_documents(docs, "find relevant docs")
-
-    assert len(result) == 2
-    # First returned should be Document 2 (index 2 in Postgres -> index 1 in Python)
-    assert result[0].page_content == "Document 2 - higher relevance."
-    assert result[0].metadata["relevance_score"] == 0.95
-    # Second returned should be Document 3 (index 3 in Postgres -> index 2 in Python)
-    assert result[1].page_content == "Document 3 - medium relevance."
-    assert result[1].metadata["relevance_score"] == 0.70
-
-
-@pytest.mark.asyncio
-async def test_compressor_arun_array_of_scores(mock_engine, mock_documents):
-    """Test async document compression with single row returning score array."""
-    conn_mock = mock_engine._pool.connect.return_value.__aenter__.return_value
-    exec_result = MagicMock()
-    # Single row containing array of scores: [score_for_doc_0, score_for_doc_1]
-    exec_result.fetchall.return_value = [[[0.2, 0.85]]]
-    conn_mock.execute.return_value = exec_result
-
-    compressor = AlloyDBDocumentCompressor(
-        engine=mock_engine,
-        top_n=1,
-    )
-    result = await compressor.acompress_documents(mock_documents, "query")
-
-    assert len(result) == 1
-    # Sorted descending by score, so doc 1 (score 0.85) should be first
-    assert result[0].page_content == "Jumps over the lazy dog."
-    assert result[0].metadata["relevance_score"] == 0.85
-
-
-@pytest.mark.asyncio
-async def test_compressor_arun_empty_documents(mock_engine):
-    """Test that passing an empty document sequence short-circuits without DB query."""
-    compressor = AlloyDBDocumentCompressor(engine=mock_engine)
-    result = await compressor.acompress_documents([], "query")
-    assert result == []
-    assert not mock_engine._pool.connect.called
-
-
-@pytest.mark.asyncio
-async def test_compressor_arun_index_error_fallback(mock_engine, mock_documents):
-    """Test fallback when row tuple index is unparseable or out of bounds."""
-    conn_mock = mock_engine._pool.connect.return_value.__aenter__.return_value
-    exec_result = MagicMock()
-    # Invalid index string "invalid_idx" triggers ValueError/IndexError fallback
-    exec_result.fetchall.return_value = [["invalid_idx", 0.75], [999, 0.25]]
-    conn_mock.execute.return_value = exec_result
-
-    compressor = AlloyDBDocumentCompressor(engine=mock_engine)
-    result = await compressor.acompress_documents(mock_documents, "query")
-
-    assert len(result) == 2
-    assert result[0].page_content == "The quick brown fox."
-    assert result[1].page_content == "Jumps over the lazy dog."
-
-
-def test_compressor_run_sync(mock_engine, mock_documents):
-    """Test synchronous compress_documents delegates to _run_as_sync with 0 warnings."""
-    compressor = AlloyDBDocumentCompressor(engine=mock_engine)
-    mock_docs_ranked = [
         Document(
-            page_content="The quick brown fox.",
-            metadata={"relevance_score": 0.9},
+            page_content="Alpha: Introduction to Machine Learning.",
+            metadata={"source": "book_a", "page": 1},
+        ),
+        Document(
+            page_content="Beta: Deep Learning and Neural Networks.",
+            metadata={"source": "book_b", "page": 42},
+        ),
+        Document(
+            page_content="Gamma: Advanced Database Systems in Cloud.",
+            metadata={"source": "book_c", "page": 100},
         ),
     ]
-
-    def mock_run_sync(coro):
-        # Explicitly close the unawaited coroutine in mock side effect to prevent RuntimeWarning
-        coro.close()
-        return mock_docs_ranked
-
-    with patch.object(mock_engine, "_run_as_sync", side_effect=mock_run_sync):
-        result = compressor.compress_documents(mock_documents, "query about a fox")
-        assert len(result) == 1
-        assert result[0].page_content == "The quick brown fox."
-        assert result[0].metadata["relevance_score"] == 0.9
 
 
 def test_compressor_default_attributes(mock_engine):
@@ -185,3 +83,331 @@ def test_compressor_default_attributes(mock_engine):
     compressor = AlloyDBDocumentCompressor(engine=mock_engine)
     assert compressor.model_id == "semantic-ranker-512@latest"
     assert compressor.top_n is None
+
+
+def test_compressor_custom_attributes(mock_engine):
+    """Test custom configuration of model_id and top_n."""
+    compressor = AlloyDBDocumentCompressor(
+        engine=mock_engine,
+        model_id="custom-ranker",
+        top_n=5,
+    )
+    assert compressor.model_id == "custom-ranker"
+    assert compressor.top_n == 5
+
+
+@pytest.mark.asyncio
+async def test_compress_documents_empty_list_async(mock_engine):
+    """Test that passing an empty document sequence short-circuits without DB query."""
+    compressor = AlloyDBDocumentCompressor(engine=mock_engine)
+    result = await compressor.acompress_documents([], "query")
+    assert result == []
+    assert not mock_engine._run_as_async.called
+    assert not mock_engine._pool.connect.called
+
+
+def test_compress_documents_empty_list_sync(mock_engine):
+    """Test synchronous compress_documents with empty document list returns empty."""
+    compressor = AlloyDBDocumentCompressor(engine=mock_engine)
+    result = compressor.compress_documents([], "query")
+    assert result == []
+    assert not mock_engine._pool.connect.called
+
+
+@pytest.mark.asyncio
+async def test_compress_documents_happy_path_async(mock_engine, sample_documents):
+    """Test standard async document compression and ranking with AlloyDB."""
+    conn_mock = mock_engine._pool.connect.return_value.__aenter__.return_value
+    exec_result = MagicMock()
+    # 1-based table output: (index, score)
+    exec_result.fetchall.return_value = [[2, 0.95], [1, 0.80], [3, 0.40]]
+    conn_mock.execute.return_value = exec_result
+
+    compressor = AlloyDBDocumentCompressor(
+        engine=mock_engine,
+        model_id="semantic-ranker-512@latest",
+        top_n=3,
+    )
+    result = await compressor.acompress_documents(sample_documents, "machine learning")
+
+    assert len(result) == 3
+    # Document 2 (index 2 -> sample_documents[1]) ranked highest
+    assert result[0].page_content == sample_documents[1].page_content
+    assert result[0].metadata["relevance_score"] == 0.95
+
+    # Document 1 (index 1 -> sample_documents[0]) ranked second
+    assert result[1].page_content == sample_documents[0].page_content
+    assert result[1].metadata["relevance_score"] == 0.80
+
+    # Document 3 (index 3 -> sample_documents[2]) ranked third
+    assert result[2].page_content == sample_documents[2].page_content
+    assert result[2].metadata["relevance_score"] == 0.40
+
+    # Verify query and parameters
+    executed_query = conn_mock.execute.call_args[0][0].text
+    assert "SELECT * FROM google_ml.rank" in executed_query
+    executed_params = conn_mock.execute.call_args[0][1]
+    assert executed_params["model_id"] == "semantic-ranker-512@latest"
+    assert executed_params["query"] == "machine learning"
+    assert executed_params["top_n"] == 3
+    assert len(executed_params["documents"]) == 3
+
+
+def test_compress_documents_happy_path_sync(mock_engine, sample_documents):
+    """Test synchronous compress_documents delegates to engine._run_as_sync and executes pipeline."""
+    conn_mock = mock_engine._pool.connect.return_value.__aenter__.return_value
+    exec_result = MagicMock()
+    # 1-based table output: (index, score)
+    exec_result.fetchall.return_value = [[2, 0.95], [1, 0.80], [3, 0.40]]
+    conn_mock.execute.return_value = exec_result
+
+    compressor = AlloyDBDocumentCompressor(engine=mock_engine)
+    result = compressor.compress_documents(sample_documents, "test query")
+
+    assert len(result) == 3
+    # Document 2 (index 2 -> sample_documents[1]) ranked highest
+    assert result[0].page_content == sample_documents[1].page_content
+    assert result[0].metadata["relevance_score"] == 0.95
+    # Document 1 (index 1 -> sample_documents[0]) ranked second
+    assert result[1].page_content == sample_documents[0].page_content
+    assert result[1].metadata["relevance_score"] == 0.80
+    # Document 3 (index 3 -> sample_documents[2]) ranked third
+    assert result[2].page_content == sample_documents[2].page_content
+    assert result[2].metadata["relevance_score"] == 0.40
+
+    assert mock_engine._run_as_sync.called
+
+
+@pytest.mark.asyncio
+async def test_compress_documents_top_n_filtering(mock_engine, sample_documents):
+    """Test that top_n restricts the number of returned documents."""
+    conn_mock = mock_engine._pool.connect.return_value.__aenter__.return_value
+    exec_result = MagicMock()
+    exec_result.fetchall.return_value = [[2, 0.98], [1, 0.85], [3, 0.60]]
+    conn_mock.execute.return_value = exec_result
+
+    compressor = AlloyDBDocumentCompressor(engine=mock_engine, top_n=1)
+    result = await compressor.acompress_documents(sample_documents, "query")
+    assert len(result) == 1
+    assert result[0].page_content == sample_documents[1].page_content
+    assert result[0].metadata["relevance_score"] == 0.98
+
+
+@pytest.mark.asyncio
+async def test_compress_documents_immutability_guarantee(mock_engine):
+    """Verify input documents are not mutated in place (SEC-01)."""
+    conn_mock = mock_engine._pool.connect.return_value.__aenter__.return_value
+    exec_result = MagicMock()
+    exec_result.fetchall.return_value = [[1, 0.95]]
+    conn_mock.execute.return_value = exec_result
+
+    compressor = AlloyDBDocumentCompressor(engine=mock_engine)
+    input_doc = Document(page_content="Test content", metadata={"source": "test"})
+    docs = [input_doc]
+
+    output = await compressor.acompress_documents(docs, "query")
+
+    assert len(output) == 1
+    assert output[0] is not input_doc
+    assert "relevance_score" not in input_doc.metadata
+    assert input_doc.metadata == {"source": "test"}
+    assert output[0].metadata == {"source": "test", "relevance_score": 0.95}
+
+
+@pytest.mark.asyncio
+async def test_compress_documents_one_based_index_bounds(mock_engine, sample_documents):
+    """Verify that 1-based PostgreSQL ordinality maps accurately (SEC-02)."""
+    conn_mock = mock_engine._pool.connect.return_value.__aenter__.return_value
+    exec_result = MagicMock()
+    # 1 maps to documents[0], 3 maps to documents[2]
+    exec_result.fetchall.return_value = [[1, 0.90], [3, 0.75]]
+    conn_mock.execute.return_value = exec_result
+
+    compressor = AlloyDBDocumentCompressor(engine=mock_engine)
+    result = await compressor.acompress_documents(sample_documents, "search query")
+
+    assert len(result) == 2
+    assert result[0].page_content == sample_documents[0].page_content
+    assert result[0].metadata["relevance_score"] == 0.90
+    assert result[1].page_content == sample_documents[2].page_content
+    assert result[1].metadata["relevance_score"] == 0.75
+
+
+@pytest.mark.asyncio
+async def test_compress_documents_zero_and_negative_index_rejection(
+    mock_engine, sample_documents
+):
+    """Verify that non-positive indices (0, -1) are rejected and skipped (SEC-02)."""
+    conn_mock = mock_engine._pool.connect.return_value.__aenter__.return_value
+    exec_result = MagicMock()
+    exec_result.fetchall.return_value = [[0, 0.99], [-1, 0.95]]
+    conn_mock.execute.return_value = exec_result
+
+    compressor = AlloyDBDocumentCompressor(engine=mock_engine)
+    result = await compressor.acompress_documents(sample_documents, "search query")
+
+    # Neither row should be mapped to sample_documents[-1]
+    assert len(result) == 0
+
+
+@pytest.mark.asyncio
+async def test_compress_documents_out_of_bounds_index_rejection(
+    mock_engine, sample_documents
+):
+    """Verify that out-of-bounds indices are safely skipped (SEC-02)."""
+    conn_mock = mock_engine._pool.connect.return_value.__aenter__.return_value
+    exec_result = MagicMock()
+    exec_result.fetchall.return_value = [[999, 0.90], [2, 0.85]]
+    conn_mock.execute.return_value = exec_result
+
+    compressor = AlloyDBDocumentCompressor(engine=mock_engine)
+    result = await compressor.acompress_documents(sample_documents, "query")
+
+    assert len(result) == 1
+    assert result[0].page_content == sample_documents[1].page_content
+    assert result[0].metadata["relevance_score"] == 0.85
+
+
+@pytest.mark.asyncio
+async def test_compress_documents_null_score_skipped(mock_engine, sample_documents):
+    """Verify that NULL database scores are skipped without index-to-score fallback (SEC-03)."""
+    conn_mock = mock_engine._pool.connect.return_value.__aenter__.return_value
+    exec_result = MagicMock()
+    exec_result.fetchall.return_value = [[2, None], [1, 0.85]]
+    conn_mock.execute.return_value = exec_result
+
+    compressor = AlloyDBDocumentCompressor(engine=mock_engine)
+    result = await compressor.acompress_documents(sample_documents, "query")
+
+    assert len(result) == 1
+    # Document 1 returned with score 0.85; document 2 with NULL score was skipped
+    assert result[0].page_content == sample_documents[0].page_content
+    assert result[0].metadata["relevance_score"] == 0.85
+
+
+@pytest.mark.asyncio
+async def test_compress_documents_unaligned_row_count_safety(mock_engine):
+    """Verify that row count exceeding document count does not cause IndexError (SEC-04)."""
+    conn_mock = mock_engine._pool.connect.return_value.__aenter__.return_value
+    exec_result = MagicMock()
+    exec_result.fetchall.return_value = [
+        ["invalid_1", 0.9],
+        ["invalid_2", 0.8],
+        [999, 0.7],
+        [0, 0.6],
+        [-5, 0.5],
+    ]
+    conn_mock.execute.return_value = exec_result
+
+    compressor = AlloyDBDocumentCompressor(engine=mock_engine)
+    docs = [Document(page_content="Single document")]
+
+    result = await compressor.acompress_documents(docs, "query")
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_compress_documents_single_column_skipped_safely(
+    mock_engine, sample_documents
+):
+    """Verify single-column rows without index are skipped, avoiding ranking inversion (SEC-05)."""
+    conn_mock = mock_engine._pool.connect.return_value.__aenter__.return_value
+    exec_result = MagicMock()
+    exec_result.fetchall.return_value = [[0.95], [0.10]]
+    conn_mock.execute.return_value = exec_result
+
+    compressor = AlloyDBDocumentCompressor(engine=mock_engine)
+    result = await compressor.acompress_documents(sample_documents, "query")
+
+    # Single column rows without document index cannot be safely mapped
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_compress_documents_validation_empty_whitespace_query(
+    mock_engine, sample_documents
+):
+    """Verify client-side validation rejects empty or whitespace queries (SEC-06)."""
+    compressor = AlloyDBDocumentCompressor(engine=mock_engine)
+
+    with pytest.raises(ValueError, match="Query string cannot be empty or whitespace."):
+        await compressor.acompress_documents(sample_documents, "")
+
+    with pytest.raises(ValueError, match="Query string cannot be empty or whitespace."):
+        await compressor.acompress_documents(sample_documents, "   \n\t  ")
+
+    assert not mock_engine._pool.connect.called
+
+
+@pytest.mark.asyncio
+async def test_compress_documents_validation_non_positive_top_n(
+    mock_engine, sample_documents
+):
+    """Verify client-side validation rejects top_n <= 0 (SEC-06)."""
+    compressor_zero = AlloyDBDocumentCompressor(engine=mock_engine, top_n=0)
+    with pytest.raises(
+        ValueError, match="top_n must be a positive integer greater than 0."
+    ):
+        await compressor_zero.acompress_documents(sample_documents, "query")
+
+    compressor_neg = AlloyDBDocumentCompressor(engine=mock_engine, top_n=-1)
+    with pytest.raises(
+        ValueError, match="top_n must be a positive integer greater than 0."
+    ):
+        await compressor_neg.acompress_documents(sample_documents, "query")
+
+    assert not mock_engine._pool.connect.called
+
+
+@pytest.mark.asyncio
+async def test_compress_documents_cross_loop_event_loop_safety():
+    """Verify that query execution routes via engine._run_as_async for cross-loop safety (SEC-07)."""
+    engine_loop = asyncio.new_event_loop()
+    thread = threading.Thread(target=engine_loop.run_forever, daemon=True)
+    thread.start()
+
+    class CrossLoopEngine(AlloyDBEngine):
+
+        def __init__(self):
+            pass
+
+    engine = CrossLoopEngine()
+    pool_mock = MagicMock()
+
+    async def connect_sim():
+        current_loop = asyncio.get_running_loop()
+        if current_loop != engine_loop:
+            raise RuntimeError("Task got Future attached to a different loop")
+        conn = AsyncMock()
+        res = MagicMock()
+        res.fetchall.return_value = [[1, 0.95]]
+        conn.execute.return_value = res
+        return conn
+
+    class SimContext:
+
+        async def __aenter__(self):
+            return await connect_sim()
+
+        async def __aexit__(self, *args):
+            pass
+
+    pool_mock.connect.side_effect = lambda: SimContext()
+    engine._pool = pool_mock
+
+    async def cross_loop_run_as_async(coro):
+        future = asyncio.run_coroutine_threadsafe(coro, engine_loop)
+        return await asyncio.wrap_future(future)
+
+    engine._run_as_async = MagicMock(side_effect=cross_loop_run_as_async)
+
+    try:
+        compressor = AlloyDBDocumentCompressor(engine=engine)
+        docs = [Document(page_content="doc1")]
+        result = await compressor.acompress_documents(docs, "query")
+        assert len(result) == 1
+        assert result[0].metadata["relevance_score"] == 0.95
+        assert engine._run_as_async.called
+    finally:
+        engine_loop.call_soon_threadsafe(engine_loop.stop)
+        thread.join(timeout=2.0)


### PR DESCRIPTION
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/langchain-google-alloydb-pg-python/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #622 🦕

## Description
Decomposed from #622 into a focused, modular PR implementing `AlloyDBDocumentCompressor` using AlloyDB AI's `google_ml.rank()` function.

### Key Features & Capabilities:
- **`AlloyDBDocumentCompressor`**: Implements LangChain's `BaseDocumentCompressor` interface to re-rank and compress document sets using AlloyDB in-database machine learning endpoints.
- **Dual Query Return Parsing**: Seamlessly parses both table-valued returns (`(index, score)`) and array-of-scores returns (`ARRAY[FLOAT]`).
- **Caller Immutability**: Guarantees caller-owned `Document` and `metadata` dictionaries are never mutated in-place (`relevance_score` is attached to new document instances).
- **Hardened Bounds & Type Safety**:
  - Validates 1-based indexing (`1 <= idx <= len(documents)`), rejecting negative or out-of-bounds indices.
  - Intercepts and rejects IEEE 754 infinity, NaN, and arithmetic overflow conversions.
  - Rejects fractional float indices to prevent silent rank truncation.
  - Robust exception handling on malformed or non-numeric score values.
- **Cross-Loop & Deadlock Safety**: Routes async queries through `engine._run_as_async` for foreign event loop compatibility (FastAPI, LangGraph) and guards synchronous calls against background loop deadlocks.
- **Documentation & Tests**: Includes Sphinx documentation in `docs/langchain_google_alloydb_pg/document_compressor.rst` and 21 comprehensive unit tests passing under `pytest -W error`.
